### PR TITLE
Enables infinite editors for (almost) all links

### DIFF
--- a/Diplo.GodMode.sln
+++ b/Diplo.GodMode.sln
@@ -13,6 +13,26 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BuildPackage", "BuildPackag
 		BuildPackage\Package.xml = BuildPackage\Package.xml
 	EndProjectSection
 EndProject
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Web", "Umbraco.Web\", "{06F3529F-F87F-46A5-A959-C7550E0D70B1}"
+	ProjectSection(WebsiteProperties) = preProject
+		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
+		Debug.AspNetCompiler.VirtualPath = "/localhost_63649"
+		Debug.AspNetCompiler.PhysicalPath = "Umbraco.Web\"
+		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_63649\"
+		Debug.AspNetCompiler.Updateable = "true"
+		Debug.AspNetCompiler.ForceOverwrite = "true"
+		Debug.AspNetCompiler.FixedNames = "false"
+		Debug.AspNetCompiler.Debug = "True"
+		Release.AspNetCompiler.VirtualPath = "/localhost_63649"
+		Release.AspNetCompiler.PhysicalPath = "Umbraco.Web\"
+		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_63649\"
+		Release.AspNetCompiler.Updateable = "true"
+		Release.AspNetCompiler.ForceOverwrite = "true"
+		Release.AspNetCompiler.FixedNames = "false"
+		Release.AspNetCompiler.Debug = "False"
+		VWDPort = "63649"
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +43,10 @@ Global
 		{456F9D93-BAB6-49DF-AD77-EC943CD5826D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{456F9D93-BAB6-49DF-AD77-EC943CD5826D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{456F9D93-BAB6-49DF-AD77-EC943CD5826D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06F3529F-F87F-46A5-A959-C7550E0D70B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06F3529F-F87F-46A5-A959-C7550E0D70B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06F3529F-F87F-46A5-A959-C7550E0D70B1}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{06F3529F-F87F-46A5-A959-C7550E0D70B1}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Diplo.GodMode.sln
+++ b/Diplo.GodMode.sln
@@ -31,6 +31,7 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Web", "Umbraco.Web\
 		Release.AspNetCompiler.FixedNames = "false"
 		Release.AspNetCompiler.Debug = "False"
 		VWDPort = "63649"
+		SlnRelativePath = "Umbraco.Web\"
 	EndProjectSection
 EndProject
 Global

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Css/godMode.css
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Css/godMode.css
@@ -25,12 +25,19 @@
     background-color: #eee;
 }
 
-.god-mode table tbody a {
+.god-mode table tbody button {
+    text-align:left;
+    background:none;
+    padding:0;
+    margin:0;
+    border:0;
+    display:inline;
+    font:inherit;
     text-decoration: underline;
     text-decoration-color: #aaa;
 }
 
-    .god-mode table tbody a:hover {
+    .god-mode table tbody button:hover {
         text-decoration: underline;
         text-decoration-color: #2bc37c;
     }

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/contentBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/contentBrowser.html
@@ -83,7 +83,7 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="c in vm.page.Items">
-                        <td><a href="{{vm.config.editContentUrl + c.Id}}" target="_blank" title="Edit"><strong>{{ c.Name }}</strong></a></td>
+                        <td><button type="button" ng-click="vm.openContent(c.Id)" title="Edit"><strong>{{ c.Name }}</strong></button></td>
                         <td><span class="{{c.Icon}}"></span>&nbsp;{{ c.Alias }}</td>
                         <td>{{ c.CreateDate | date:'short' : 'UTC' }}</td>
                         <td>{{ c.CreatorName }}</td>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/contentBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/contentBrowser.html
@@ -1,8 +1,8 @@
 ﻿<div ng-controller="GodMode.ContentBrowser.Controller as vm" class="god-mode">
 
-    <umb-editor-view footer="false">
+    <umb-editor-view footer="model.infiniteMode">
 
-        <godmode-header heading="Content Browser" title="Because content is king"></godmode-header>
+        <godmode-header heading="Content Browser" title="Because content is king" on-reload="vm.fetchContent(vm.sort.column)"></godmode-header>
 
         <umb-editor-container>
 
@@ -117,6 +117,18 @@
 
         </umb-editor-container>
 
+        <umb-editor-footer ng-if="model.infiniteMode">
+
+            <umb-editor-footer-content-right>
+                <umb-button type="button"
+                            button-style="link"
+                            label-key="general_close"
+                            shortcut="esc"
+                            action="model.close()">
+                </umb-button>
+            </umb-editor-footer-content-right>
+
+        </umb-editor-footer>
     </umb-editor-view>
 
 </div>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/dataTypeBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/dataTypeBrowser.html
@@ -1,8 +1,8 @@
 ﻿<div ng-controller="GodMode.DataTypeBrowser.Controller as vm" class="god-mode">
 
-    <umb-editor-view footer="false">
+    <umb-editor-view footer="model.infiniteMode">
 
-        <godmode-header heading="DataType Browser" title="Are you my data-type?"></godmode-header>
+        <godmode-header heading="DataType Browser" title="Are you my data-type?" on-reload="vm.reload"></godmode-header>
 
         <umb-editor-container>
 
@@ -72,7 +72,20 @@
                 <p>This only checks for datatypes that are used directly by a document type. Datatypes that are nested within another datatype (eg. within Nested Content) are not discoverable via the Umbraco API.</p>
             </div>
    
+
         </umb-editor-container>
+        <umb-editor-footer ng-if="model.infiniteMode">
+
+            <umb-editor-footer-content-right>
+                <umb-button type="button"
+                            button-style="link"
+                            label-key="general_close"
+                            shortcut="esc"
+                            action="model.close()">
+                </umb-button>
+            </umb-editor-footer-content-right>
+
+        </umb-editor-footer>
 
     </umb-editor-view>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/dataTypeBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/dataTypeBrowser.html
@@ -58,8 +58,8 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="d in vm.dataTypes | filter: vm.filterDataTypes | orderBy: vm.sort.column : vm.sort.reverse">
-                        <td><a href="{{vm.config.editDataTypeUrl + d.Id}}" target="_blank" title="Edit DataType"><strong>{{ d.Name }}</strong></a></td>
-                        <td><a href="{{vm.config.baseTreeUrl + 'docTypeBrowser/' + d.Alias}}" target="_blank" title="Search for in doc types"><i class="icon icon-search"></i> {{ d.Alias }}</a></td>
+                        <td><button type="button" ng-click="vm.openDataType(d.Id)" title="Edit DataType"><strong>{{ d.Name }}</strong></button></td>
+                        <td><button type="button" ng-click="vm.openDocTypeBrowser(d.Alias)" title="Search for in doc types"><i class="icon icon-search"></i> {{ d.Alias }}</button></td>
                         <td>{{ d.DbType }}</td>
                         <td><godmode-True-False value="d.IsUsed"></godmode-True-False></td>
                         <td><div>{{ d.Id }}</div><code>{{ d.Udi }}</code></td>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/diagnosticBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/diagnosticBrowser.html
@@ -2,7 +2,7 @@
 
     <umb-editor-view footer="false">
 
-        <godmode-header heading="{{vm.heading}}" title="She canna take any more, captain. She's gonna blow!"></godmode-header>
+        <godmode-header heading="{{vm.heading}}" title="She canna take any more, captain. She's gonna blow!" on-reload="vm.init()"></godmode-header>
 
         <umb-editor-container>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/docTypeBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/docTypeBrowser.html
@@ -93,15 +93,15 @@
 
             <br />
 
-            <div ng-repeat="ct in vm.contentTypes | filter: vm.filterContentTypes as results">               
+            <div ng-repeat="ct in vm.contentTypes | filter: vm.filterContentTypes as results">
 
                 <umb-box>
-                    <div class="umb-box-header box-opener" ng-click="ct.IsOpen = !ct.IsOpen">
-                        <div class="span10">
+                    <div class="umb-box-header box-opener flex">
+                        <div class="span12" ng-click="ct.IsOpen = !ct.IsOpen">
                             <h4><i class="{{ ct.Icon }}"></i>&nbsp;{{ ct.Name }} <small>({{ ct.Alias }})</small></h4>
                         </div>
-                        <div class="span2 text-right">
-                            <a href="{{vm.config.editDocTypeUrl + ct.Id}}" title="Edit {{ ct.Name }} doctype" aria-label="Edit {{ct.Name}}" target="_blank"><span class="btn btn-action">Edit</span></a>
+                        <div class="">
+                            <button type="button" ng-click="vm.openContentType(ct.Id)" title="Edit {{ ct.Name }} doctype" aria-label="Edit {{ct.Name}}" class="btn btn-action">Edit</button>
                         </div>
                     </div>
 
@@ -127,7 +127,7 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="tmp in ct.Templates">
-                                    <td><a href="{{config.editTemplateUrl + tmp.Id}}" target="_blank" title="Edit Template">{{ tmp.Name }}</a></td>
+                                    <td><button type="button" ng-click="vm.openTemplate(tmp.Id)" title="Edit Template">{{ tmp.Name }}</button></td>
                                     <td>{{ tmp.Alias }}</td>
                                     <td>{{ tmp.Path }}</td>
                                 </tr>
@@ -147,7 +147,7 @@
                                 <tr ng-repeat="prop in ct.Properties">
                                     <td title="{{ prop.Description }}">{{ prop.Name }}</td>
                                     <td>{{ prop.Alias }}</td>
-                                    <td><a href="{{vm.config.editDataTypeUrl + prop.EditorId}}" target="_blank" title="Edit">{{ prop.EditorAlias }}</a></td>
+                                    <td><button type="button" ng-click="vm.openDataType(prop.EditorId)" title="Edit">{{ prop.EditorAlias }}</button></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -165,7 +165,7 @@
                                 <tr ng-repeat="prop in ct.CompositionProperties">
                                     <td title="{{ prop.Description }}">{{ prop.Name }}</td>
                                     <td>{{ prop.Alias }}</td>
-                                    <td><a href="{{vm.config.editDataTypeUrl + prop.EditorId}}" target="_blank" title="Edit">{{ prop.EditorAlias }}</a></td>
+                                    <td><button type="button" ng-click="vm.openDataType(prop.EditorId)" title="Edit">{{ prop.EditorAlias }}</button></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -181,7 +181,7 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="comp in ct.Compositions">
-                                    <td><i class="{{ comp.Icon }}"></i><a href="{{vm.config.editDocTypeUrl + comp.Id}}" title="Edit Composition" target="_blank">{{ comp.Name }}</a></td>
+                                    <td><i class="{{ comp.Icon }}"></i><button type="button" ng-click="vm.openContentType(comp.Id)" title="Edit Composition" target="_blank">{{ comp.Name }}</button></td>
                                     <td>{{ comp.Alias }}</td>
                                     <td><small>{{ comp.Description }}</small></td>
                                 </tr>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/docTypeBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/docTypeBrowser.html
@@ -1,8 +1,8 @@
 ﻿<div ng-controller="GodMode.DocTypeBrowser.Controller as vm" class="god-mode">
 
-    <umb-editor-view footer="false">
+    <umb-editor-view footer="model.infiniteMode">
 
-        <godmode-header heading="Document Type Browser" title="Because who doesn't love a doc type?"></godmode-header>
+        <godmode-header heading="Document Type Browser" title="Because who doesn't love a doc type?" on-reload="vm.reload()"></godmode-header>
 
         <umb-editor-container>
 
@@ -196,6 +196,18 @@
             <p ng-if="results.length === 0" class="alert alert-info alert-block">Sorry, there are no documents that match your chosen search criteria. Try changing the filters at the top of the page.</p>
 
         </umb-editor-container>
+        <umb-editor-footer ng-if="model.infiniteMode">
+
+            <umb-editor-footer-content-right>
+                <umb-button type="button"
+                            button-style="link"
+                            label-key="general_close"
+                            shortcut="esc"
+                            action="model.close()">
+                </umb-button>
+            </umb-editor-footer-content-right>
+
+        </umb-editor-footer>
 
     </umb-editor-view>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/godModeHeader.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/godModeHeader.html
@@ -14,7 +14,7 @@
                 <li>
                     <div>
                         <div class="umb-sub-views-nav-item">
-                            <a ng-href="" ng-click="reload()">
+                            <a ng-href="" ng-click="onReload()">
                                 <i class="icon icon-refresh"></i>
                                 <span class="umb-sub-views-nav-item-text ng-binding">Reload</span>
                             </a>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/mediaBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/mediaBrowser.html
@@ -48,7 +48,7 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="m in vm.page.Items">
-                        <td><a href="{{vm.config.editMediaUrl + m.Id}}" target="_blank" title="Edit"><strong>{{ m.Name }}</strong></a></td>
+                        <td><button type="button" ng-click="vm.openMedia(m.Id)" title="Edit"><strong>{{ m.Name }}</strong></button></td>
                         <td>{{ m.Alias }}</td>
                         <td title="{{ m.Ext }}">{{ m.Type }}</td>
                         <td>{{ m.Size | godModeFileSize }}</td>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/mediaBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/mediaBrowser.html
@@ -2,7 +2,7 @@
 
     <umb-editor-view footer="false">
 
-        <godmode-header heading="Media Browser" title="Why can't clients organise their files?"></godmode-header>
+        <godmode-header heading="Media Browser" title="Why can't clients organise their files?" on-reload="vm.fetchContent()"></godmode-header>
 
         <umb-editor-container>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/memberBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/memberBrowser.html
@@ -50,7 +50,7 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="m in vm.page.Items">
-                        <td><strong><a href="#/member/member/edit/{{m.Id}}" target="_blank" title="Edit">{{ m.Username }}</a></strong></td>
+                        <td><strong><button type="button" ng-click="vm.openMember(m.Id)" title="Edit">{{ m.Username }}</button></strong></td>
                         <td>{{ m.Name }}</td>
                         <td><a href="mailto:{{m.Email}}" target="_blank" title="Email">{{ m.Email }}</a></td>
                         <td>{{ m.CreateDate | date:'short' : 'utc' }}</td>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/memberBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/memberBrowser.html
@@ -2,7 +2,7 @@
 
     <umb-editor-view footer="false">
 
-        <godmode-header heading="Member Browser" title="Because everyone likes browsing a member, right?"></godmode-header>
+        <godmode-header heading="Member Browser" title="Because everyone likes browsing a member, right?" on-reload="vm.fetchMembers()"></godmode-header>
 
         <umb-editor-container>
 
@@ -50,7 +50,7 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="m in vm.page.Items">
-                        <td><strong><button type="button" ng-click="vm.openMember(m.Id)" title="Edit">{{ m.Username }}</button></strong></td>
+                        <td><strong><button type="button" ng-click="vm.openMember(m.Udi)" title="Edit">{{ m.Username }}</button></strong></td>
                         <td>{{ m.Name }}</td>
                         <td><a href="mailto:{{m.Email}}" target="_blank" title="Email">{{ m.Email }}</a></td>
                         <td>{{ m.CreateDate | date:'short' : 'utc' }}</td>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/memberBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/memberBrowser.html
@@ -50,7 +50,7 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="m in vm.page.Items">
-                        <td><strong><button type="button" ng-click="vm.openMember(m.Udi)" title="Edit">{{ m.Username }}</button></strong></td>
+                        <td><strong><a href="#/member/member/edit/{{m.Id}}" target="_blank" title="Edit">{{ m.Username }}</a></strong></td>
                         <td>{{ m.Name }}</td>
                         <td><a href="mailto:{{m.Email}}" target="_blank" title="Email">{{ m.Email }}</a></td>
                         <td>{{ m.CreateDate | date:'short' : 'utc' }}</td>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/partialBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/partialBrowser.html
@@ -2,7 +2,7 @@
 
     <umb-editor-view footer="false">
 
-        <godmode-header heading="Partial Browser" title="Are you partial to a nice partial?"></godmode-header>
+        <godmode-header heading="Partial Browser" title="Are you partial to a nice partial?" on-reload="vm.init()"></godmode-header>
 
         <umb-editor-container>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/partialBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/partialBrowser.html
@@ -46,8 +46,8 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="p in vm.partials | filter: vm.filterPartials | orderBy: vm.sort.column : vm.sort.reverse">
-                        <td><a href="{{ vm.config.editPartialUrl + p.Path}}" target="_blank" title="Edit Partial">{{ p.Name }}</a></td>
-                        <td><a href="{{ vm.config.editTemplateUrl + p.TemplateId}}" title="Edit Template" target="_blank">{{ p.TemplateAlias }}</a></td>
+                        <td><button type="button" ng-click="vm.openPartial(p.Path)" title="Edit Partial">{{ p.Name }}</button></td>
+                        <td><button type="button" ng-click="vm.openTemplate(p.TemplateId)" title="Edit Template">{{ p.TemplateAlias }}</button></td>
                         <td><godmode-True-False value="p.IsCached"></godmode-True-False></td>
                     </tr>
                 </tbody>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/partialBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/partialBrowser.html
@@ -46,7 +46,7 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="p in vm.partials | filter: vm.filterPartials | orderBy: vm.sort.column : vm.sort.reverse">
-                        <td><button type="button" ng-click="vm.openPartial(p.Path)" title="Edit Partial">{{ p.Name }}</button></td>
+                        <td><a href="{{ vm.config.editPartialUrl + p.Path}}" target="_blank" title="Edit Partial">{{ p.Name }}</a></td>
                         <td><button type="button" ng-click="vm.openTemplate(p.TemplateId)" title="Edit Template">{{ p.TemplateAlias }}</button></td>
                         <td><godmode-True-False value="p.IsCached"></godmode-True-False></td>
                     </tr>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/reflectionBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/reflectionBrowser.html
@@ -2,7 +2,7 @@
 
     <umb-editor-view footer="false">
 
-        <godmode-header heading="{{vm.heading}} Browser" title="I'll be your mirror, reflect what you are"></godmode-header>
+        <godmode-header heading="{{vm.heading}} Browser" title="I'll be your mirror, reflect what you are" on-reload="vm.init()"></godmode-header>
 
         <umb-editor-container>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/templateBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/templateBrowser.html
@@ -39,12 +39,12 @@
             <div ng-repeat="temp in vm.templates | filter: vm.filterTemplates as results">
 
                 <umb-box>
-                    <div class="umb-box-header box-opener" ng-click="temp.IsOpen = !temp.IsOpen">
-                        <div class="span10">
+                    <div class="umb-box-header box-opener flex">
+                        <div class="span12" ng-click="temp.IsOpen = !temp.IsOpen">
                             <h4><strong>{{ temp.Name }}</strong> <small>({{ temp.Alias }})</small> <i ng-if="temp.IsMaster" class="icon icon-key color-amber" title="Master" aria-label="Master template"></i></h4>
                         </div>
-                        <div class="span2 text-right">
-                            <a class="accordion-toggle" href="{{vm.config.editTemplateUrl + temp.Id}}" title="Edit Template" target="_blank"><span class="btn btn-action">Edit</span></a>
+                        <div class="">
+                            <button type="button" ng-click="vm.openTemplate(temp.Id)" title="Edit Template" class="btn btn-action">Edit</button>
                         </div>
                     </div>
 
@@ -69,7 +69,7 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="t in temp.Parents">
-                                    <td width="50%"><a href="{{vm.config.editTemplateUrl + t.Id}}" target="_blank" title="Edit Template">{{ t.Name }}</a></td>
+                                    <td width="50%"><button type="button" ng-click="vm.openTemplate(t.Id)" title="Edit Template">{{ t.Name }}</button></td>
                                     <td width="50%">{{ t.FilePath }}</td>
                                 </tr>
                             </tbody>
@@ -85,7 +85,7 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="p in temp.Partials">
-                                    <td><a href="{{vm.config.editPartialUrl + p.Path}}" target="_blank" title="Edit Partial">{{ p.Name }}</a></td>
+                                    <td><button type="button" ng-click="vm.openPartial(p.Path)" title="Edit Partial">{{ p.Name }}</button></td>
                                     <td><godmode-True-False value="p.IsCached"></godmode-True-False></td>
                                 </tr>
                             </tbody>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/templateBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/templateBrowser.html
@@ -2,7 +2,7 @@
 
     <umb-editor-view footer="false">
 
-        <godmode-header heading="Template Browser" title="I'm a blueprint for a view, I am!"></godmode-header>
+        <godmode-header heading="Template Browser" title="I'm a blueprint for a view, I am!" on-reload="vm.init()"></godmode-header>
 
         <umb-editor-container>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/templateBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/templateBrowser.html
@@ -85,7 +85,7 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="p in temp.Partials">
-                                    <td><button type="button" ng-click="vm.openPartial(p.Path)" title="Edit Partial">{{ p.Name }}</button></td>
+                                    <td><a href="{{vm.config.editPartialUrl + p.Path}}" target="_blank" title="Edit Partial">{{ p.Name }}</a></td>
                                     <td><godmode-True-False value="p.IsCached"></godmode-True-False></td>
                                 </tr>
                             </tbody>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/typeBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/typeBrowser.html
@@ -2,7 +2,7 @@
 
     <umb-editor-view footer="false">
 
-        <godmode-header heading="Interface Browser" title="Because no one wants to be tightly coupled, right?"></godmode-header>
+        <godmode-header heading="Interface Browser" title="Because no one wants to be tightly coupled, right?" on-reload="vm.init()"></godmode-header>
 
         <umb-editor-container>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/usageBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/usageBrowser.html
@@ -2,7 +2,7 @@
 
     <umb-editor-view footer="false">
 
-        <godmode-header heading="Usage Browser" title="Because statistics don't lie..."></godmode-header>
+        <godmode-header heading="Usage Browser" title="Because statistics don't lie..." on-reload="vm.fetchContent()"></godmode-header>
 
         <umb-editor-container>
 

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/usageBrowser.html
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/GodModeTree/usageBrowser.html
@@ -54,7 +54,7 @@
                         <td>
                             <span class="{{c.Icon}}"></span>
                             <strong>
-                                <a ng-show="c.Type === 'Content'" href="{{vm.config.baseViewUrl + 'contentBrowser/' + c.Alias + '/'}}" title="View related content">{{ c.Alias }}</a>
+                                <button type="button" ng-click="vm.openContentBrowser(c.Alias)" ng-show="c.Type === 'Content'" title="View related content">{{ c.Alias }}</button>
                                 <span ng-show="c.Type !== 'Content'">{{ c.Alias }}</span>
                             </strong>
                         </td>

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.Config.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.Config.js
@@ -45,13 +45,11 @@
                 restrict: 'E',
                 scope: {
                     heading: '@',
-                    tooltip: '@'
+                    tooltip: '@',
+                    onReload: '&'
                 },
                 link: function (scope, element, attrs) {
                     scope.version = godModeConfig.config.version;
-                    scope.reload = function () {
-                        $route.reload();
-                    };
                 },
                 templateUrl: "/App_Plugins/DiploGodMode/BackOffice/GodModeTree/godModeHeader.html"
             };

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.ContentBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.ContentBrowser.Controller.js
@@ -1,7 +1,7 @@
 ﻿(function () {
     'use strict';
     angular.module("umbraco").controller("GodMode.ContentBrowser.Controller",
-        function ($routeParams, navigationService, godModeResources, godModeConfig) {
+        function ($routeParams, navigationService, godModeResources, godModeConfig, editorService) {
 
             var vm = this;
             vm.isLoading = true;
@@ -25,6 +25,7 @@
             vm.criteria.Trashed = vm.triStateOptions[0];
 
             vm.fetchContent = function (orderBy) {
+                vm.isLoading = true;
                 godModeResources.getContentPaged(vm.currentPage, vm.itemsPerPage, vm.criteria, orderBy).then(function (data) {
                     vm.page = data;
                     vm.currentPage = vm.page.CurrentPage;
@@ -86,5 +87,19 @@
 
                 vm.fetchContent();
             });
+
+            vm.openContent = function (contentId) {
+                const editor = {
+                    id: contentId,
+                    submit: function () {
+                        vm.fetchContent();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.contentEditor(editor);
+            };
         });
 })();

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DataTypeBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DataTypeBrowser.Controller.js
@@ -1,10 +1,9 @@
 ﻿(function () {
     'use strict';
     angular.module("umbraco").controller("GodMode.DataTypeBrowser.Controller",
-        function ($routeParams, navigationService, godModeResources, godModeConfig) {
+        function ($routeParams, navigationService, godModeResources, godModeConfig, editorService) {
 
             var vm = this;
-            vm.isLoading = true;
 
             navigationService.syncTree({ tree: $routeParams.tree, path: [-1, $routeParams.method], forceReload: false });
 
@@ -17,10 +16,14 @@
             vm.triStateOptions = godModeResources.getTriStateOptions();
             vm.search.isUsed = vm.triStateOptions[0];
 
-            godModeResources.getDataTypesStatus().then(function (data) {
-                vm.dataTypes = data;
-                vm.isLoading = false;
-            });
+            var init = function () {
+                vm.isLoading = true;
+                godModeResources.getDataTypesStatus().then(function (data) {
+                    vm.dataTypes = data;
+                    vm.isLoading = false;
+                });
+            };
+            init();
 
             vm.sortBy = function (column) {
                 vm.sort.column = column;
@@ -57,6 +60,36 @@
                 }
 
                 return d;
+            };
+
+            vm.openDataType = function (dataTypeId) {
+                const editor = {
+                    view: "views/common/infiniteeditors/datatypesettings/datatypesettings.html",
+                    id: dataTypeId,
+                    submit: function () {
+                        init();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.open(editor);
+            };
+
+            vm.openDocTypeBrowser = function (dataTypeAlias) {
+                const editor = {
+                    view: "/App_Plugins/DiploGodMode/BackOffice/GodModeTree/docTypeBrowser.html",
+                    id: dataTypeAlias,
+                    submit: function () {
+                        init();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.open(editor);
             };
         });
 })();

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DataTypeBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DataTypeBrowser.Controller.js
@@ -25,6 +25,8 @@
             };
             init();
 
+            vm.reload = function () { init(); };
+
             vm.sortBy = function (column) {
                 vm.sort.column = column;
                 vm.sort.reverse = !vm.sort.reverse;

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DiagnosticBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DiagnosticBrowser.Controller.js
@@ -15,17 +15,21 @@
             vm.sort.reverse = false;
             vm.heading = "Diagnostics";
 
-            godModeResources.getEnvironmentDiagnostics().then(function (data) {
-                vm.diagnostics = data;
-                vm.groups = vm.diagnostics.map(function (g) {
-                    return { Id: g.Id, Title: g.Title };
+            vm.init = function () {
+                vm.isLoading = true;
+                godModeResources.getEnvironmentDiagnostics().then(function (data) {
+                    vm.diagnostics = data;
+                    vm.groups = vm.diagnostics.map(function (g) {
+                        return { Id: g.Id, Title: g.Title };
+                    });
+
+                    vm.search.group = vm.groups[0];
+                    vm.selectGroup(vm.search.group);
+
+                    vm.isLoading = false;
                 });
-
-                vm.search.group = vm.groups[0];
-                vm.selectGroup(vm.search.group);
-
-                vm.isLoading = false;
-            });
+            };
+            vm.init();
 
             vm.selectGroup = function (group) {
                 var selectedGroup = vm.diagnostics.filter(function (g) {

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DocTypeBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DocTypeBrowser.Controller.js
@@ -1,10 +1,10 @@
 ﻿(function () {
     'use strict';
     angular.module("umbraco").controller("GodMode.DocTypeBrowser.Controller",
-        function ($routeParams, navigationService, godModeResources, godModeConfig) {
+        function ($routeParams, navigationService, godModeResources, godModeConfig, editorService) {
 
             var vm = this;
-            vm.isLoading = true;
+            vm.contentTypes = [];
 
             navigationService.syncTree({ tree: $routeParams.tree, path: [-1, $routeParams.method], forceReload: false });
 
@@ -19,33 +19,43 @@
             vm.search.allowedAtRoot = vm.triStateOptions[0];
             vm.search.hasCompositions = vm.triStateOptions[0];
 
-            godModeResources.getContentTypeMap().then(function (data) {
-                vm.contentTypes = data;
-                vm.isLoading = false;
-            });
+            var init = function () {
+                vm.isLoading = true;
+                var openContentTypes = vm.contentTypes.filter(function (ct) { return ct.IsOpen; }).map(function (ct) { return ct.Id; });
 
-            godModeResources.getPropertyGroups().then(function (data) {
-                vm.propertyGroups = data;
-            });
+                godModeResources.getContentTypeMap().then(function (data) {
+                    vm.contentTypes = data;
+                    if (openContentTypes) {
+                        vm.contentTypes.map(function (ct) { if (openContentTypes.indexOf(ct.Id) > -1) ct.IsOpen = true; });
+                    }
+                    vm.isLoading = false;
+                });
 
-            godModeResources.getCompositions().then(function (data) {
-                vm.compositions = data;
-            });
+                godModeResources.getPropertyGroups().then(function (data) {
+                    vm.propertyGroups = data;
+                });
 
-            godModeResources.getDataTypes().then(function (data) {
-                vm.dataTypes = data;
-            });
+                godModeResources.getCompositions().then(function (data) {
+                    vm.compositions = data;
+                });
 
-            godModeResources.getPropertyEditors().then(function (data) {
-                vm.propertyEditors = data;
-                if (param !== "browse") {
-                    vm.propertyEditors.filter(function (elem) {
-                        if (elem.Alias === param) {
-                            vm.search.propertyEditor = elem;
-                        }
-                    });
-                }
-            });
+                godModeResources.getDataTypes().then(function (data) {
+                    vm.dataTypes = data;
+                });
+
+                godModeResources.getPropertyEditors().then(function (data) {
+                    vm.propertyEditors = data;
+                    if (param !== "browse") {
+                        vm.propertyEditors.filter(function (elem) {
+                            if (elem.Alias === param) {
+                                vm.search.propertyEditor = elem;
+                            }
+                        });
+                    }
+                });
+            };
+
+            init();
 
             vm.filterContentTypes = function (ct) {
 
@@ -110,6 +120,50 @@
                 }
 
                 return ct;
+            };
+
+            vm.openContentType = function (contentTypeId) {
+                const editor = {
+                    id: contentTypeId,
+                    submit: function () {
+                        init();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.documentTypeEditor(editor);
+                return false;
+            };
+
+            vm.openDataType = function (dataTypeId) {
+                const editor = {
+                    view: "views/common/infiniteeditors/datatypesettings/datatypesettings.html",
+                    id: dataTypeId,
+                    submit: function () {
+                        init();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.open(editor);
+            };
+
+            vm.openTemplate = function (templateId) {
+                const editor = {
+                    id: templateId,
+                    submit: function () {
+                        init();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.templateEditor(editor);
             };
         });
 })();

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DocTypeBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.DocTypeBrowser.Controller.js
@@ -55,6 +55,8 @@
                 });
             };
 
+            vm.reload = function () { init(); };
+
             init();
 
             vm.filterContentTypes = function (ct) {

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.MediaBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.MediaBrowser.Controller.js
@@ -1,7 +1,7 @@
 ﻿(function () {
     'use strict';
     angular.module("umbraco").controller("GodMode.MediaBrowser.Controller",
-        function ($routeParams, navigationService, godModeResources, godModeConfig) {
+        function ($routeParams, navigationService, godModeResources, godModeConfig, editorService) {
 
             var vm = this;
             vm.isLoading = true;
@@ -21,6 +21,7 @@
             vm.sort.column = "id";
 
             vm.fetchContent = function (orderBy, orderByDir) {
+                vm.isLoading = true;
                 godModeResources.getMedia(vm.currentPage, vm.itemsPerPage, vm.criteria, orderBy, orderByDir).then(function (data) {
                     vm.page = data;
                     vm.isLoading = false;
@@ -71,5 +72,19 @@
             vm.getMediaTypes();
 
             vm.fetchContent();
+
+            vm.openMedia = function (mediaId) {
+                const editor = {
+                    id: mediaId,
+                    submit: function () {
+                        vm.fetchContent();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.mediaEditor(editor);
+            };
         });
 })();

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.MemberBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.MemberBrowser.Controller.js
@@ -1,10 +1,9 @@
 ﻿(function () {
     'use strict';
     angular.module("umbraco").controller("GodMode.MemberBrowser.Controller",
-        function ($routeParams, navigationService, godModeResources, godModeConfig) {
+        function ($routeParams, navigationService, godModeResources, godModeConfig, editorService) {
 
             var vm = this;
-            vm.isLoading = true;
 
             navigationService.syncTree({ tree: $routeParams.tree, path: [-1, $routeParams.method], forceReload: false });
 
@@ -72,5 +71,20 @@
                 vm.memberGroups = data;
                 vm.fetchMembers();
             });
+
+            vm.openMember = function (memberId) {
+                const editor = {
+                    view: "views/member/edit.html",
+                    id: memberId,
+                    submit: function () {
+                        vm.fetchMembers();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.open(editor);
+            };
         });
 })();

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.MemberBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.MemberBrowser.Controller.js
@@ -71,20 +71,5 @@
                 vm.memberGroups = data;
                 vm.fetchMembers();
             });
-
-            vm.openMember = function (memberId) {
-                const editor = {
-                    view: "views/member/edit.html",
-                    id: memberId,
-                    submit: function () {
-                        vm.fetchMembers();
-                        editorService.close();
-                    },
-                    close: function () {
-                        editorService.close();
-                    }
-                };
-                editorService.open(editor);
-            };
         });
 })();

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.PartialBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.PartialBrowser.Controller.js
@@ -16,7 +16,7 @@
             vm.triStateOptions = godModeResources.getTriStateOptions();
             vm.search.isCached = vm.triStateOptions[0];
 
-            var init = function () {
+            vm.init = function () {
                 vm.isLoading = true;
 
                 godModeResources.getTemplates().then(function (data) {
@@ -32,7 +32,7 @@
                 });
             };
 
-            init();
+            vm.init();
 
             vm.sortBy = function (column) {
                 vm.sort.column = column;
@@ -61,7 +61,7 @@
                 const editor = {
                     id: templateId,
                     submit: function () {
-                        init();
+                        vm.init();
                         editorService.close();
                     },
                     close: function () {
@@ -76,7 +76,7 @@
                     view: "views/partialViews/edit.html",
                     id: path,
                     submit: function () {
-                        init();
+                        vm.init();
                         editorService.close();
                     },
                     close: function () {

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.PartialBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.PartialBrowser.Controller.js
@@ -70,20 +70,5 @@
                 };
                 editorService.templateEditor(editor);
             };
-
-            vm.openPartial = function (path) {
-                const editor = {
-                    view: "views/partialViews/edit.html",
-                    id: path,
-                    submit: function () {
-                        vm.init();
-                        editorService.close();
-                    },
-                    close: function () {
-                        editorService.close();
-                    }
-                };
-                editorService.open(editor);
-            };
         });
 })();

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.ReflectionBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.ReflectionBrowser.Controller.js
@@ -18,37 +18,39 @@
             vm.heading = "";
 
             var id = $routeParams.id;
-            var getControllersFunction;
-
-            if ($routeParams.id === "api") {
-                getControllersFunction = godModeResources.getApiControllers();
-                vm.heading = "API Controller";
-            }
-            else if ($routeParams.id === "surface") {
-                getControllersFunction = godModeResources.getSurfaceControllers();
-                vm.heading = "Surface Controller";
-            }
-            else if ($routeParams.id === "models") {
-                getControllersFunction = godModeResources.getPublishedContentModels();
-                vm.heading = "Published Content Model";
-            }
-            else if ($routeParams.id === "render") {
-                getControllersFunction = godModeResources.getRenderMvcControllers();
-                vm.heading = "RenderMvc Controller";
-            }
-            else if ($routeParams.id === "converters") {
-                getControllersFunction = godModeResources.getPropertyValueConveters();
-                vm.heading = "Property Value Converter";
-            }
-            else if ($routeParams.id === "composers") {
-                getControllersFunction = godModeResources.getComposers();
-                vm.heading = "Composer";
-            }
 
             navigationService.syncTree({ tree: $routeParams.tree, path: [-1, "reflectionTree", $routeParams.method + $routeParams.id], forceReload: false });
 
             vm.init = function () {
                 vm.isLoading = true;
+
+                var getControllersFunction;
+
+                if ($routeParams.id === "api") {
+                    getControllersFunction = godModeResources.getApiControllers();
+                    vm.heading = "API Controller";
+                }
+                else if ($routeParams.id === "surface") {
+                    getControllersFunction = godModeResources.getSurfaceControllers();
+                    vm.heading = "Surface Controller";
+                }
+                else if ($routeParams.id === "models") {
+                    getControllersFunction = godModeResources.getPublishedContentModels();
+                    vm.heading = "Published Content Model";
+                }
+                else if ($routeParams.id === "render") {
+                    getControllersFunction = godModeResources.getRenderMvcControllers();
+                    vm.heading = "RenderMvc Controller";
+                }
+                else if ($routeParams.id === "converters") {
+                    getControllersFunction = godModeResources.getPropertyValueConveters();
+                    vm.heading = "Property Value Converter";
+                }
+                else if ($routeParams.id === "composers") {
+                    getControllersFunction = godModeResources.getComposers();
+                    vm.heading = "Composer";
+                }
+
                 getControllersFunction.then(function (data) {
                     vm.controllers = data;
                     vm.isLoading = false;

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.ReflectionBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.ReflectionBrowser.Controller.js
@@ -47,10 +47,14 @@
 
             navigationService.syncTree({ tree: $routeParams.tree, path: [-1, "reflectionTree", $routeParams.method + $routeParams.id], forceReload: false });
 
-            getControllersFunction.then(function (data) {
-                vm.controllers = data;
-                vm.isLoading = false;
-            });
+            vm.init = function () {
+                vm.isLoading = true;
+                getControllersFunction.then(function (data) {
+                    vm.controllers = data;
+                    vm.isLoading = false;
+                });
+            };
+            vm.init();
 
             vm.filterByUmbraco = function (c) {
                 if (!c.IsUmbraco === vm.search.isUmbraco.value) {

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.TemplateBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.TemplateBrowser.Controller.js
@@ -67,20 +67,5 @@
                 };
                 editorService.templateEditor(editor);
             };
-
-            vm.openPartial = function (path) {
-                const editor = {
-                    view: "views/partialViews/edit.html",
-                    id: path,
-                    submit: function () {
-                        vm.init();
-                        editorService.close();
-                    },
-                    close: function () {
-                        editorService.close();
-                    }
-                };
-                editorService.open(editor);
-            };
         });
 })();

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.TemplateBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.TemplateBrowser.Controller.js
@@ -12,7 +12,7 @@
             vm.search = {};
 
 
-            var init = function () {
+            vm.init = function () {
                 var openTemplates = vm.templates.filter(function (t) { return t.IsOpen; }).map(function (t) { return t.Id; });
                 vm.isLoading = true;
 
@@ -28,7 +28,7 @@
                 });
             };
 
-            init();
+            vm.init();
 
             vm.filterTemplates = function (temp) {
                 if (vm.search.partial) {
@@ -58,7 +58,7 @@
                 const editor = {
                     id: templateId,
                     submit: function () {
-                        init();
+                        vm.init();
                         editorService.close();
                     },
                     close: function () {
@@ -73,7 +73,7 @@
                     view: "views/partialViews/edit.html",
                     id: path,
                     submit: function () {
-                        init();
+                        vm.init();
                         editorService.close();
                     },
                     close: function () {

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.TypeBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.TypeBrowser.Controller.js
@@ -13,10 +13,14 @@
             vm.sort.column = "Name";
             vm.sort.reverse = false;
 
-            godModeResources.getAssemblies().then(function (data) {
-                vm.assemblies = data;
-                vm.isLoading = false;
-            });
+            vm.init = function () {
+                vm.isLoading = true;
+                godModeResources.getAssemblies().then(function (data) {
+                    vm.assemblies = data;
+                    vm.isLoading = false;
+                });
+            };
+            vm.init();
 
             vm.getTypes = function (type) {
                 vm.types = [];

--- a/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.UsageBrowser.Controller.js
+++ b/Umbraco.Web/App_Plugins/DiploGodMode/BackOffice/Scripts/GodMode.UsageBrowser.Controller.js
@@ -1,7 +1,7 @@
 ﻿(function () {
     'use strict';
     angular.module("umbraco").controller("GodMode.UsageBrowser.Controller",
-        function ($routeParams, navigationService, godModeResources, godModeConfig) {
+        function ($routeParams, navigationService, godModeResources, godModeConfig, editorService) {
 
             var vm = this;
             vm.isLoading = true;
@@ -16,6 +16,7 @@
             vm.usage = [];
 
             vm.fetchContent = function (orderBy) {
+                vm.isLoading = true;
                 orderBy = orderBy === undefined ? "CT.Alias" : orderBy;
 
                 godModeResources.getContentUsage(null, orderBy).then(function (data) {
@@ -43,5 +44,20 @@
             };
 
             vm.fetchContent();
+
+            vm.openContentBrowser = function (contentTypeAlias) {
+                const editor = {
+                    view: "/App_Plugins/DiploGodMode/BackOffice/GodModeTree/contentBrowser.html",
+                    id: contentTypeAlias,
+                    submit: function () {
+                        init();
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                };
+                editorService.open(editor);
+            };
         });
 })();


### PR DESCRIPTION
#16 

This one enables infinite editors (using the editorService).

I reworked the header directive a bit, to be able to reload GodModes own browsers when used in an infinite editor.

In this PR, all links, except those going to partial views and members open in an infinite editor. Partial Views and Members doesn't work in infinite editors before Umbraco 8.3 (https://github.com/umbraco/Umbraco-CMS/pull/6460 and https://github.com/umbraco/Umbraco-CMS/pull/6461), so these are going to have their own PRs :)

[see gif](https://i.imgur.com/kMNXJNY.gifv)