### PR TITLE
Added `versionAssemblyName` to `package.manifest` file

### DIFF
--- a/Diplo.GodMode/App_Plugins/DiploGodMode/package.manifest
+++ b/Diplo.GodMode/App_Plugins/DiploGodMode/package.manifest
@@ -2,6 +2,7 @@
   "name": "Diplo GodMode",
   "version": "10.3.2",
   "allowPackageTelemetry": true,
+  "versionAssemblyName": "Diplo.GodMode",
   "javascript": [
     "~/App_Plugins/DiploGodMode/backoffice/Scripts/GodMode.Config.js",
     "~/App_Plugins/DiploGodMode/backoffice/Scripts/GodMode.Resources.js",


### PR DESCRIPTION
Hi @DanDiplo 

I've been playing around with adding an improved package list to my [Iddqd](https://github.com/abjerner/Limbo.Umbraco.Iddqd) package, since Umbraco's list in the **Packages** section doesn't really have that much information.

For packages using a `package.manifest` file (opposed to a C# manifest filter), I'm trying to detect if the package has an underlying DLL, and if so, grab some extra information from the DLL. Umbraco is already doing something similar for their package telemetry, for which they introduced the `versionAssemblyName` property that you can add to your `package.manifest` file.

I had your package installed as well, and noticed that this property was not in your `package.manifest` file, so I figured that I might as well submit a PR for adding it. The property is in no way required, but would help both me and Umbraco gather additonal package information.

The property is unfortunately not mentioned in the official Umbraco documentation, but you can see some more information i the Umbraco source code:

https://github.com/umbraco/Umbraco-CMS/blob/v13/contrib/src/Umbraco.Core/Manifest/PackageManifest.cs#L85-L92

In my package, this would mean that I can show the bottom **Assembly** box with some additional information:

![image](https://github.com/DanDiplo/Umbraco.GodMode/assets/3634580/be8c268c-7c8c-42b4-b760-09c9d148b07c)

