### PR TITLE
Handle Keyed Services

### DIFF
--- a/Diplo.GodMode.Testsite/TestComposer.cs
+++ b/Diplo.GodMode.Testsite/TestComposer.cs
@@ -8,8 +8,8 @@ namespace Diplo.GodMode.Testsite
     {
         public void Compose(IUmbracoBuilder builder)
         {
-            builder.Services.AddSingleton<IDiploFoo, DiploFoo>();
-            builder.Services.AddKeyedSingleton<IDiploFoo, DiploFoo>("keyed");
+            builder.Services.AddScoped<IDiploFoo, DiploFoo>();
+            builder.Services.AddKeyedScoped<IDiploFoo, DiploFoo>("keyed");
         }
     }
 

--- a/Diplo.GodMode.Testsite/TestComposer.cs
+++ b/Diplo.GodMode.Testsite/TestComposer.cs
@@ -8,7 +8,8 @@ namespace Diplo.GodMode.Testsite
     {
         public void Compose(IUmbracoBuilder builder)
         {
-            builder.Services.AddScoped<IDiploFoo, DiploFoo>();
+            builder.Services.AddSingleton<IDiploFoo, DiploFoo>();
+            builder.Services.AddKeyedSingleton<IDiploFoo, DiploFoo>("keyed");
         }
     }
 

--- a/Diplo.GodMode/App_Plugins/DiploGodMode/backoffice/godModeTree/serviceBrowser.html
+++ b/Diplo.GodMode/App_Plugins/DiploGodMode/backoffice/godModeTree/serviceBrowser.html
@@ -75,11 +75,12 @@
             <table class="table table-hover">
                 <thead>
                     <tr>
-                        <th style="width:25%"><godmode-sortable sort-by="vm.sortBy('Name')" column="Name" sort="vm.sort">Name</godmode-sortable></th>
+                        <th style="width:20%"><godmode-sortable sort-by="vm.sortBy('Name')" column="Name" sort="vm.sort">Name</godmode-sortable></th>
                         <th style="width:20%"><godmode-sortable sort-by="vm.sortBy('Namespace')" column="Namespace" sort="vm.sort">Namespace</godmode-sortable></th>
-                        <th style="width:25%"><godmode-sortable sort-by="vm.sortBy('ImplementName')" column="ImplementName" sort="vm.sort">Implemented By</godmode-sortable></th>
+                        <th style="width:20%"><godmode-sortable sort-by="vm.sortBy('ImplementName')" column="ImplementName" sort="vm.sort">Implemented By</godmode-sortable></th>
                         <th style="width:20%"><godmode-sortable sort-by="vm.sortBy('ImplementNamespace')" column="ImplementNamespace" sort="vm.sort">Implemented Namespace</godmode-sortable></th>
                         <th style="width:10%"><godmode-sortable sort-by="vm.sortBy('Lifetime')" column="Lifetime" sort="vm.sort">Lifetime</godmode-sortable></th>
+                        <th style="width:10%"><godmode-sortable sort-by="vm.sortBy('Key')" column="Key" sort="vm.sort">Key</godmode-sortable></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -89,6 +90,7 @@
                         <td title="{{c.ImplementFullName}}"><strong>{{ c.ImplementName }}</strong></td>
                         <td><small>{{ c.ImplementNamespace }}</small></td>
                         <td>{{ c.Lifetime }}</td>
+                        <td>{{ c.Key }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/Diplo.GodMode/Composers/GodModeComposer.cs
+++ b/Diplo.GodMode/Composers/GodModeComposer.cs
@@ -20,9 +20,8 @@ namespace Diplo.GodMode.Composers
             builder.Services.AddScoped<IUmbracoDatabaseService, UmbracoDatabaseService>();
             builder.Services.AddScoped<IUmbracoDataService, UmbracoDataService>();
             builder.Services.AddScoped<IUtilitiesService, UtilitiesService>();
-
-            RegisteredServiceCollection registeredServiceCollection = new(builder.Services);
-            builder.Services.AddSingleton<RegisteredServiceCollection>(services => registeredServiceCollection);
+            
+            builder.Services.AddSingleton(services => new RegisteredServiceCollection(builder.Services));
         }
     }
 }

--- a/Diplo.GodMode/Models/RegisteredServiceCollection.cs
+++ b/Diplo.GodMode/Models/RegisteredServiceCollection.cs
@@ -20,14 +20,19 @@ namespace Diplo.GodMode.Models
     {
         public RegisteredService(ServiceDescriptor service)
         {
-            this.Name = service.ServiceType?.ToGenericTypeString();
-            this.Namespace = service.ServiceType?.Namespace;
-            this.FullName = service.ServiceType?.AssemblyQualifiedName;
-            this.ImplementFullName = service.ImplementationType?.AssemblyQualifiedName;
-            this.ImplementName = service.ImplementationType?.ToGenericTypeString();
-            this.ImplementNamespace = service.ImplementationType?.Namespace;
+            var serviceType = service.ServiceType;
+            var implementationType = service.IsKeyedService
+                ? service.KeyedImplementationType
+                : service.ImplementationType;
+
+            this.Name = serviceType?.ToGenericTypeString();
+            this.Namespace = serviceType?.Namespace;
+            this.FullName = serviceType?.AssemblyQualifiedName;
+            this.ImplementFullName = implementationType?.AssemblyQualifiedName;
+            this.ImplementName = implementationType?.ToGenericTypeString();
+            this.ImplementNamespace = implementationType?.Namespace;
             this.Lifetime = service.Lifetime.ToString();
-            this.IsPublic = (service.ServiceType?.IsPublic ?? false) && (service.ImplementationType?.IsPublic ?? false);
+            this.IsPublic = (serviceType?.IsPublic ?? false) && (implementationType?.IsPublic ?? false);
         }
 
         public string Name { get; set; }

--- a/Diplo.GodMode/Models/RegisteredServiceCollection.cs
+++ b/Diplo.GodMode/Models/RegisteredServiceCollection.cs
@@ -26,12 +26,13 @@ namespace Diplo.GodMode.Models
                 : service.ImplementationType;
 
             this.Name = serviceType?.ToGenericTypeString();
-            this.Namespace = serviceType?.Namespace;
             this.FullName = serviceType?.AssemblyQualifiedName;
-            this.ImplementFullName = implementationType?.AssemblyQualifiedName;
+            this.Namespace = serviceType?.Namespace;
             this.ImplementName = implementationType?.ToGenericTypeString();
+            this.ImplementFullName = implementationType?.AssemblyQualifiedName;
             this.ImplementNamespace = implementationType?.Namespace;
             this.Lifetime = service.Lifetime.ToString();
+            this.Key = service.IsKeyedService ? service.ServiceKey?.ToString() : string.Empty;
             this.IsPublic = (serviceType?.IsPublic ?? false) && (implementationType?.IsPublic ?? false);
         }
 
@@ -50,5 +51,7 @@ namespace Diplo.GodMode.Models
         public string ImplementFullName { get; set; }
 
         public string Lifetime { get; set; }
+
+        public string Key { get; set; }
     }
 }


### PR DESCRIPTION
This adds support for the new .NET feature [keyed services][keyed-services].

Resolves the `InvalidOperationException` "This service descriptor is keyed. Your service provider may not support keyed services." when using keyed services in your .NET solution.

Resolves the issue where some services were not appearing due to collection being lazy loaded prior to later services registering via `IComposer`.

Outputs the key used to register the service in the Umbraco backoffice view:

<img width="1451" alt="Screenshot 2024-08-09 at 22 47 47" src="https://github.com/user-attachments/assets/329c5e85-e8b6-4721-a4b3-7eb46a4a1b0c">

[keyed-services]: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-8.0#keyed-services