### PR TITLE
V17 element type usage

### DIFF
--- a/Diplo.GodMode.Tests/ElementTypeUsageTests.cs
+++ b/Diplo.GodMode.Tests/ElementTypeUsageTests.cs
@@ -1,0 +1,112 @@
+using Diplo.GodMode.Services;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Diplo.GodMode.Tests;
+
+[TestClass]
+public sealed class ElementTypeUsageTests
+{
+    [TestMethod]
+    public void GetConfiguredElementTypeReferences_ReturnsContentAndSettingsReferences()
+    {
+        var contentKey = Guid.NewGuid();
+        var settingsKey = Guid.NewGuid();
+        var configuration = new BlockListConfiguration
+        {
+            Blocks =
+            [
+                new BlockListConfiguration.BlockConfiguration
+                {
+                    ContentElementTypeKey = contentKey,
+                    SettingsElementTypeKey = settingsKey
+                }
+            ]
+        };
+
+        var references = UmbracoDatabaseService.GetConfiguredElementTypeReferences(configuration).ToArray();
+
+        Assert.AreEqual(2, references.Length);
+        Assert.IsTrue(references.Any(x => x.ElementTypeKey == contentKey && x.SourceType == "ConfigurationContent"));
+        Assert.IsTrue(references.Any(x => x.ElementTypeKey == settingsKey && x.SourceType == "ConfigurationSettings"));
+    }
+
+    [TestMethod]
+    public void GetConfiguredElementTypeReferences_PreservesRepeatedConfigurationOccurrences()
+    {
+        var contentKey = Guid.NewGuid();
+        var configuration = new BlockGridConfiguration
+        {
+            Blocks =
+            [
+                new BlockGridConfiguration.BlockGridBlockConfiguration { ContentElementTypeKey = contentKey },
+                new BlockGridConfiguration.BlockGridBlockConfiguration { ContentElementTypeKey = contentKey }
+            ]
+        };
+
+        var references = UmbracoDatabaseService.GetConfiguredElementTypeReferences(configuration).ToArray();
+
+        Assert.AreEqual(2, references.Length);
+        Assert.IsTrue(references.All(x => x.ElementTypeKey == contentKey));
+    }
+
+    [TestMethod]
+    public void GetConfiguredElementTypeReferences_IgnoresUnsupportedConfiguration()
+    {
+        var references = UmbracoDatabaseService.GetConfiguredElementTypeReferences(new object()).ToArray();
+
+        Assert.AreEqual(0, references.Length);
+    }
+
+    [TestMethod]
+    public void BuildElementTypeUsageCte_SqlServerPreservesOccurrencesAndReadsRichTextBlocks()
+    {
+        var sql = UmbracoDatabaseService.BuildElementTypeUsageCte(includeLibrarySources: false, isSqlite: false);
+
+        StringAssert.Contains(sql, "$.blocks.contentData");
+        StringAssert.Contains(sql, "$.blocks.settingsData");
+        StringAssert.Contains(sql, "ISJSON(upd.textValue)");
+        Assert.IsFalse(sql.Contains("SELECT DISTINCT", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void BuildElementTypeUsageCte_SqlitePreservesOccurrencesAndReadsRichTextBlocks()
+    {
+        var sql = UmbracoDatabaseService.BuildElementTypeUsageCte(includeLibrarySources: false, isSqlite: true);
+
+        StringAssert.Contains(sql, "$.blocks.contentData");
+        StringAssert.Contains(sql, "$.blocks.settingsData");
+        StringAssert.Contains(sql, "json_valid(upd.textValue)");
+        Assert.IsFalse(sql.Contains("SELECT DISTINCT", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void BuildElementTypeUsageCte_OmitsV18SourcesWhenElementsSchemaIsUnavailable()
+    {
+        var sql = UmbracoDatabaseService.BuildElementTypeUsageCte(includeLibrarySources: false, isSqlite: false);
+
+        Assert.IsFalse(sql.Contains("umbracoElement", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(sql.Contains("'ElementPicker'", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void BuildElementTypeUsageCte_IncludesV18SourcesWhenElementsSchemaIsAvailable()
+    {
+        var sql = UmbracoDatabaseService.BuildElementTypeUsageCte(includeLibrarySources: true, isSqlite: false);
+
+        StringAssert.Contains(sql, "FROM umbracoElement ue");
+        StringAssert.Contains(sql, "rt.alias = 'umbElement'");
+        StringAssert.Contains(sql, "'ElementPicker'");
+        Assert.IsFalse(sql.Contains("SELECT DISTINCT", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void BuildElementTypeUsageKeyPredicate_UsesCaseInsensitiveComparisonForSqlite()
+    {
+        Assert.AreEqual(
+            "ElementTypeKey = @4 COLLATE NOCASE",
+            UmbracoDatabaseService.BuildElementTypeUsageKeyPredicate(isSqlite: true));
+        Assert.AreEqual(
+            "ElementTypeKey = @4",
+            UmbracoDatabaseService.BuildElementTypeUsageKeyPredicate(isSqlite: false));
+    }
+}

--- a/Diplo.GodMode/Client/package-lock.json
+++ b/Diplo.GodMode/Client/package-lock.json
@@ -14,44 +14,10 @@
         "vite": "^8.0.16"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -106,9 +72,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -142,9 +108,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -167,9 +133,9 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.1.tgz",
-      "integrity": "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.2.tgz",
+      "integrity": "sha512-R2NMf3wq97rh1mjz33WJQU8svz3F0RYUjvx/QzXucjpSqQ3O5huTdDjErG4fMxSr1X+X56NuDrqtGfHmo1TRUQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -187,16 +153,16 @@
       }
     },
     "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz",
-      "integrity": "sha512-DoPJGxVApDlktP1yYLjmOrF0YBEqb32ieCbx1S1i09n8TyCgdoh4yQaQ3kp0sMTauH+bwNKPsFh7S8qiWCoKZA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.2.tgz",
+      "integrity": "sha512-ZhCFSKI2ipZHEbgmtUHdyddvRU3wJ4elgCfYUC7T7hZa4EivSrVflTQf2w+v3TuaYxR1Y2V2kq3otqTttrrK8Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
-        "yaml": "2.8.3"
+        "js-yaml": "4.1.1"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -206,16 +172,16 @@
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.97.0.tgz",
-      "integrity": "sha512-WZkKgrDlZpxKlDv2HkBCzaAYeuM+EtZKFmKGBv9/JblAKpX3JQTROi7PzlCZE3eisetRPSakbcRgn+LGyB7EiQ==",
+      "version": "0.97.3",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.97.3.tgz",
+      "integrity": "sha512-4sR6/E/POuy7aPZW9DDjhObzZCq7eSJWiW0+epXeKNczoTWEwdOyWFy9Ca/CnXYlZ3oJsrv0ZD0OO+YuczT7CA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "0.8.1",
-        "@hey-api/json-schema-ref-parser": "1.4.1",
-        "@hey-api/shared": "0.4.2",
+        "@hey-api/codegen-core": "0.8.2",
+        "@hey-api/json-schema-ref-parser": "1.4.2",
+        "@hey-api/shared": "0.4.5",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "@lukeed/ms": "2.0.2",
@@ -238,15 +204,15 @@
       }
     },
     "node_modules/@hey-api/shared": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.2.tgz",
-      "integrity": "sha512-4fconS10E0Xr4/acV8G+BkApxaIStxrT0GhB9BDTQWvrFTy5/nV933SyFk8qImcbpKvgv9hpn3N+7bV8oFrbjA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.5.tgz",
+      "integrity": "sha512-au4eHpBXAe1du0iMp6ESYuEaMS2jsoEyrbcT246btRhI9rMeQFEs7ZjtcMGXGsxhpaR38A8cPGNHx7QOrWAdMw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "0.8.1",
-        "@hey-api/json-schema-ref-parser": "1.4.1",
+        "@hey-api/codegen-core": "0.8.2",
+        "@hey-api/json-schema-ref-parser": "1.4.2",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
@@ -358,9 +324,9 @@
       "peer": true
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
-      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
@@ -388,9 +354,9 @@
       }
     },
     "node_modules/@microsoft/signalr": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
-      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.11.tgz",
+      "integrity": "sha512-FulOJ2EEtKvLQcswe/U7v8pzyXyk7Jua5xgWJPPwyQU/2Z9ORvKcVjyO75VvLsem+CJ1ORRexJ+7Bz1FCei2aw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -402,29 +368,10 @@
         "ws": "^7.5.10"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -432,9 +379,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
       "cpu": [
         "arm64"
       ],
@@ -449,9 +396,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
       "cpu": [
         "arm64"
       ],
@@ -466,9 +413,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
       "cpu": [
         "x64"
       ],
@@ -483,9 +430,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
       "cpu": [
         "x64"
       ],
@@ -500,9 +447,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
       "cpu": [
         "arm"
       ],
@@ -517,9 +464,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
       "cpu": [
         "arm64"
       ],
@@ -534,9 +481,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
       "cpu": [
         "arm64"
       ],
@@ -551,9 +498,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
       "cpu": [
         "ppc64"
       ],
@@ -568,9 +515,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
       "cpu": [
         "s390x"
       ],
@@ -585,9 +532,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
       "cpu": [
         "x64"
       ],
@@ -602,9 +549,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
       "cpu": [
         "x64"
       ],
@@ -619,9 +566,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
       "cpu": [
         "arm64"
       ],
@@ -635,29 +582,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
       "cpu": [
         "arm64"
       ],
@@ -672,9 +600,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
       "cpu": [
         "x64"
       ],
@@ -696,9 +624,9 @@
       "license": "MIT"
     },
     "node_modules/@tiptap/core": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.5.tgz",
-      "integrity": "sha512-L1lhWz6ujGny8LduTJ7MBWYhzigwOvfUJUrJ7IzOJSuy3+OAzisdGDD1GV7LEO/hU0Hr2Mkm1wajRIHExvS9HQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.30.1.tgz",
+      "integrity": "sha512-HWEO6Qi8fI8Zt8X4atVV6GxthJx7Vrjr6L5YFq4OkjYJ7HG2/bFw6IKsDA3jOYgY4DM9lv8IadaiWUQ2JJRIBA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -707,13 +635,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.5.tgz",
-      "integrity": "sha512-ajyP5W8fG5Hrru47T/eF3xMKOpNvWofgNJqBTeNuGl02sYxsy9a4EunyFxudsaZP9WW3VOD4SaIWr5+MqpbnOQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.30.1.tgz",
+      "integrity": "sha512-nUBIPmf9fKfBzeMpQsexsHw3/ICzDfBK8DN9uLf5wO3I/gWycAByynvfNIqfHyl6Q77QgTIHrdjihEXUSYzeJg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -722,13 +650,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.5.tgz",
-      "integrity": "sha512-l/uDtpJISiFFyfctvnODNWBN/XPZI1jVZRacTRDDnSn8+x6KQ7G2qgFYueU7KvVJGDFVT39Iio56mcFRG/Pozg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.30.1.tgz",
+      "integrity": "sha512-xnEGv7evFQquT0r/byjBt5iqDYQi6bF/W7DPO2rAG0z33mShDEUHhE407jakMiOSYNUilFjuQj1naLvwpQC3Bw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -737,13 +666,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.5.tgz",
-      "integrity": "sha512-cf54fG9AybU8NgPMv1TOcoqAkELeRc/VpnSCt/rIJZphWQx9nsFmrtkrlCatrIcCaGtNZYwlHlMnC5LVVMu0uA==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.30.1.tgz",
+      "integrity": "sha512-9bf4VgIxaOe+c7W20WZGUU5d2SFNGSpVwDGU/7jGlnjobzR7ZhDK/THk9JQr8OpvZrVN8Nmf84ZD3axjt+h/hQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -752,13 +681,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.22.5"
+        "@tiptap/extension-list": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.5.tgz",
-      "integrity": "sha512-mwDNOJC9rYbDu/JcqrN4dbUQRklJU8Fuk2raxD/IvFw9qUIcPCmxQ2XT9UTKmZz/Ju7Kdy72fss6XpgWv6gLAQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.30.1.tgz",
+      "integrity": "sha512-oqLEOLZel3lrLhACP4vMhH5RNbV9yxFsJYiOmQjjEFEoCEWWxVfJuhZ+8NFS3mUCdgy77G62XimjEvqC3+7V7Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -767,13 +696,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.5.tgz",
-      "integrity": "sha512-d123kCfLdJTi4fue1m0+TNFztDkmIRSZGZmGu6H9KqwG5Q7IzjT9o8lzRsz+pXxYqHvqgYmXoEpM6srbzXx/Ag==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.30.1.tgz",
+      "integrity": "sha512-j19Ml9BpvHgTMSN4SfkJ26B5xSuHaxPXvMoXyAX1iOoSc4J92sCqShLGgpmtce42sIroYFRs4sBv0ndBRDcxtA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -782,14 +711,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5",
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.5.tgz",
-      "integrity": "sha512-8NJERd+pCtvSuEP4C4WMGYmRRCV12ePZL7bC+QUdFlbdXg+kNZS0zZ7hh879tYA0Kidbi8rWWD1Tx+H2ezkmMw==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.30.1.tgz",
+      "integrity": "sha512-aeMhO7EDoJyl5AGkF9hDQ9e52s18L8oYdbYjzcmXeo0YuXeaxbZCuUueVH4DnTfV7/vSkDRpDkk4TFF5LfKQpg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -798,13 +727,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.5.tgz",
-      "integrity": "sha512-Mp40DaFrY3sEUVtFqmxrR0BmU4G3k8GCYYNGqNa9OqWv7BrcFDC03V2n3okESDKt4MKkzhQQmypq+ouLy8dLfA==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.30.1.tgz",
+      "integrity": "sha512-N3R5rA01WX/brGm1Qcnf2KLu0xkyGbRPMsHzzl1YG2sOLQM9t+FQi1T8WvSJiOpfYBVaWQkILUoCymADSpgUAg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -813,13 +742,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.22.5"
+        "@tiptap/extensions": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.5.tgz",
-      "integrity": "sha512-4WkMu7qqjbsm8hCQS+8X+la1wjriN0SKoRdvpfKH33qM50MB34tYJuGLAO+y7TTh4MMMco3AZCKPBL5JVMqNIg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.30.1.tgz",
+      "integrity": "sha512-dp13WaPNj32SkDN9tun0OtwtfdO/y52BJWigwXPgpUFLEyr8hQ84TxXL3rDshGHE4Eyjdd+erdBHisjBEV9vwQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -828,13 +757,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.22.5"
+        "@tiptap/extensions": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.5.tgz",
-      "integrity": "sha512-n0R2mUVYZU2AVbJhg/WcY9+zx690wVwvsItHJf0DrYbf1tCYHx+PRHUt/AoXk6u8BSmnkb8/FDziS8m3mjfpSg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.30.1.tgz",
+      "integrity": "sha512-2emcEkSSj+Y3dXXEugKQZDNeWCum0LBuKFmun7SiJyLOdxNuRnxwm2l4/LLiEHGDJBchDti4Oo8jZGLTRt4uog==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -843,13 +772,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.5.tgz",
-      "integrity": "sha512-hjyEG4947PAhMBfP1G6B0QAh6+y9mp2C5BQmNjprA05/lQzDAT7KFZzNh8ZVp3ol6aICKq/N1gFOW9Dc/9FUOw==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.30.1.tgz",
+      "integrity": "sha512-TGM1ZNeH/D8HQK59vFMZql2gesMoHy+6nLq3mFsYpiRT2TShMGoq+K7SC+ty6N5a/k4M82ZQrDq8t4zjiiS5xA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -858,13 +787,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.5.tgz",
-      "integrity": "sha512-vUV0/ugIbXOc8SJib0h8UMhgcqZXWu/dkEhlswZN4VVven1o5enkfxEiDw+OyIJHi5rUkrdhsQ/KTxG/Xb7X8A==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.30.1.tgz",
+      "integrity": "sha512-fTaSDapNV3cRgsek94z/Z4+Fyr0UpkE8/9PdSvt9MHYo/2yx3mmuamEJwUhUCpe7gDfzGdrMMsRpDOcd0b1ZEQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -873,14 +802,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5",
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.22.5.tgz",
-      "integrity": "sha512-ezMzA6w6UsPesQp6fxTQojI/IkGJLmkwR/VGTimva7sudP3HdSW8k3SGBkjfvp0L2xqUrC/l4nWOchu01A/xtQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.30.1.tgz",
+      "integrity": "sha512-LChYqHC0u7dq9/zj9R+SYgT04tuT549tzFeu8Ymo1TJ46Y9Iy3BfwlETZRvyV8NkC/eoGqUevJeD3HtG/vMaog==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -889,13 +818,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.5.tgz",
-      "integrity": "sha512-4T8baSiLkeIymTgEwirxDFt5YgYofkP3m1+MGYdGy2HKcOK+1vpvlPhEO1X5qtZngtJW5S4+njKjinRg52A4PA==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.30.1.tgz",
+      "integrity": "sha512-KldMtozKk8OBHexo6akCQpJCWMgJ5OwPYuEOJO+vFjgw6VS+9N16peIo5dY+vXAiVIZL+swEsBp4barwz7NiLw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -904,32 +833,32 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.5.tgz",
-      "integrity": "sha512-d671MvF3GPKoS2OVxjIlQ7hIE7MS3hREdR+d4cvnnoiLLD+ZJ6KgDnxmWqF0a1s4qxLWK2KxKRSOIfYGE31QWQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.30.1.tgz",
+      "integrity": "sha512-krq5yHDT4K+u2r7rS0CGk/yafyAKY1gbxexfbMmq+jyHtUUrr0UuCT1nOTa61bV3zX1nrObM1lKSpZ5FgbfdhQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "linkifyjs": "^4.3.2"
+        "linkifyjs": "^4.3.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5",
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.5.tgz",
-      "integrity": "sha512-cVO3ZHCgxAWZ4zrFSs81FO2nyCk1wb2EHkpLpW98FzbJLkN9rDkazhW99P3HRWy/CvUldOT+8ecI1YrQtBojMg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.30.1.tgz",
+      "integrity": "sha512-LizBu3fWrjifsL7QxKt+NhnHJDVGW/WWL+5asfqyznMqCZTy6tvPJ2W39pUHH2dBaVtzRIkAlsgWjDcNX/ep/Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -938,14 +867,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5",
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.5.tgz",
-      "integrity": "sha512-W7uTmyKLhlsvuTPLv+8WwnsY+mlikBFIoLSvVcBaFt4MwpsZ+DeB6KQg02Y7tbtaAnG7rXu9Fvw2QORh2P728A==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.30.1.tgz",
+      "integrity": "sha512-8QqIKvEqXKlT4Cv3ZySHAq1jzKimT/UnFxNBCnkBg+aZBgImvPlRFdN5nFs0elxiSQ7Jtt6k29aOyrkjxgyeew==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -954,13 +883,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.22.5"
+        "@tiptap/extension-list": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.5.tgz",
-      "integrity": "sha512-cGUnxJ0y515e1bVHNjUmbx7oWHoEon59w6BA5N2KwV9iW2mZZchlTX4yxJSOX+ixeVRChsa7YwC3Z1jUZ6AMEg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.30.1.tgz",
+      "integrity": "sha512-ju39AnbRyWr1vG4GnMM7BritV/9heGMeH103wccXgJU9hOEqzwmN9zpf5CZqeRnXOjzwQiojrEL+nwm5MnuboA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -969,13 +898,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.22.5"
+        "@tiptap/extension-list": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.5.tgz",
-      "integrity": "sha512-OXdh4k4CNrukwiSdWdEQ49uvgnqvR0Z9aNSP4HI5/kZQ/Te1NtRtYCpUrzWyO/7CtjcCisXHti0o9C/TV8YMbQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.30.1.tgz",
+      "integrity": "sha512-kJ4+4I1n4b5jV8OpWH+dbKOlIWTWVPv/fxDQKZuAT/a0DRoowpRoAuGJ0Nk9/Azeqel6c8Ocb4n1J7xLR6Xl2Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -984,13 +913,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.22.5"
+        "@tiptap/extension-list": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.5.tgz",
-      "integrity": "sha512-52KCto4+XKpnBWpIufspWLyq4UWxAWC72ANPdGuIhbi72NRTabiTbTVN40uwGSPkyakeESG0/vKdWJCVvB4f0g==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.30.1.tgz",
+      "integrity": "sha512-1kAYoyIF88l2qPgHi9ZeS5D5N7TzdJg3FvVCOJvUplQtBIwrsNAx6zaH/16NKN7kRiW7zETMKXMKkhL6MIvnDg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -999,13 +928,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.5.tgz",
-      "integrity": "sha512-42WrrFK5gOom/0znH85x12Mw5IQ/6O6DWdyUWoRIrNA/qJpuHtU8oVU+bIgU2tuomMGHruRjIzgBQv5sBjEtww==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.30.1.tgz",
+      "integrity": "sha512-vyF8TPTARaN5coGrFwqVREPXDONE4SXJMIxo9qMaBJWl7723m+Enpy7qmFscnwifW5XTpOA8jKl/QJ7qud/ljw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1014,13 +943,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-subscript": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.22.5.tgz",
-      "integrity": "sha512-dee60jEhXxvaejgTqFCgPDD747S1WDu9sxuwUKvEDyE53xGhqHh25eCDUJ9BGPRa/9UurbGHe0KbXryTsbcaBg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.30.1.tgz",
+      "integrity": "sha512-D9eaOWJqH/oq5+qCBL0YzH2iTwGBDO8N1OfRWDV+8lFYfRSUHhMr9tTrs7h7akik9X9S0H1V2oEVm6DAdY+X2Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1029,14 +958,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5",
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-superscript": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.22.5.tgz",
-      "integrity": "sha512-Ta9epX6CY9vOQjZAnY/HY7Lo/ixSrRwdDU8yOhkoO9pkYNA/e8l5xhf1T04qnBQ1+QaOZzpLTYlfQJrHzqcJmQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.30.1.tgz",
+      "integrity": "sha512-DJY1X+v5rs4HUwXvMHtWlYFlJjtHqWvQxO+yNIp3IvSu9Grh1UTfYROI4eIrUzNTUAx2ShT6UdCmiWF7SwYhjw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1045,14 +974,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5",
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-table": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.22.5.tgz",
-      "integrity": "sha512-GMBM07bCwzHx1NK08zXRr2mNTDnP78Hd0VxFsRBIDFddDMZ2qG5jhwKHXN5cHMTrdWokWFUjvnEeJeV3guHoGg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.30.1.tgz",
+      "integrity": "sha512-frZvuNbgi4ohLGeweHMfKWoCVAlCUB/BULgzjLMaFSaSpVGk2KVeoYtCJf9wR240IAj3t7tti3A7E4Ymz98qOQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1061,14 +990,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5",
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.5.tgz",
-      "integrity": "sha512-bzpDOdAEo1JeoVZDIyV0oY0jGXkEG+AzF70SzHoRSjOvFDtKWunyXf9eO1OnOr2/fmMcckT2qwUBNBMQplWBzw==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.30.1.tgz",
+      "integrity": "sha512-Zt3Ik95ZKJx5YNzC6TUXWTNBHUfRH/qVENmqfPjA7x7q4cqNdOEU+tX9DrlFjgxu/x0k48dlQS0Kaop24/vihA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1077,13 +1006,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-text-align": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.22.5.tgz",
-      "integrity": "sha512-LNUinhsZJC+/Vm7ugtghSjqlO64FQuww8oJkHq54Oh135fJ+kY2yBRakYFeH0P0gl4VPJH13AUetLF696CM2UQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.30.1.tgz",
+      "integrity": "sha512-oYAYySpwcgcHSdZw8xgMqF+sCNUgM7v/2UQj0amsBOLbk5VMfiLdJp5Ku+z5aqCwBBUjb6sInh1Amzd3q57w4A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1092,13 +1021,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-text-style": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.22.5.tgz",
-      "integrity": "sha512-jt63jy8YbhZJUGMxTUzeivLhowGtFp6YbCFrrmZJ7G6IHu8X8LJzO81ksz5nT5l8DKpldGwnINUfA6iE91JIAg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.30.1.tgz",
+      "integrity": "sha512-VLci8TnjAxBGbNlailFabGAv8ayPR8roGeNhS25UG90XJxiO2FZUHmOv+vqrciQ7Zfs5BXyrGQY+Yb3dAtHgIw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1107,13 +1036,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.5.tgz",
-      "integrity": "sha512-9ut09rJD0iEbS6sk7yd2j6IwuFDLTNmDEGTDLodvqAfi+bq7ddsTDv0YviXoZaA9sdHAdTEVr2ITy2m6WK5jpA==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.30.1.tgz",
+      "integrity": "sha512-Xro/EzEgWW+46ztrw5f4epDWQvcGpD+HUykzigj30bpIS8Vv4XDXFt+89dAcyDC7zRUMQULlWZV0UCyRLFEKBw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1122,13 +1051,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5"
+        "@tiptap/core": "3.30.1"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.5.tgz",
-      "integrity": "sha512-Ifg4MzKCj3uRqe3ieTwYnomu2y4p7EXr2avVSKZYfh12i2dyWe2Gkn1KuZDREANVE+gHqFlQjJRYzhJFwzSCrg==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.30.1.tgz",
+      "integrity": "sha512-prNrvF1oMj+tngCLmZgXzQfuUuvYMbCe2sEPXXKJPqJNNffHd2wAuUZ0h6UQS5aRILaxB2kN1/yfwpxnhRpwYA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1137,30 +1066,31 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.5",
-        "@tiptap/pm": "3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.5.tgz",
-      "integrity": "sha512-Cr9Mv4igxvI2tKMiahw48sZxva3PfDzypErH8IB82N+9qa9n9ygVMt0BOaDg53hLKxEEVeYr2S/wCcJIVFgBTw==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.30.1.tgz",
+      "integrity": "sha512-2bHY+ihexKpfBURbAD+ahY0+lWle0TueTK80GAGYqZ/G7ErAPOmzN5RVAGMyZJI4wDkcFycRNLi3k0/3VT9a1A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-changeset": "^2.3.0",
-        "prosemirror-commands": "^1.6.2",
-        "prosemirror-dropcursor": "^1.8.1",
-        "prosemirror-gapcursor": "^1.3.2",
-        "prosemirror-history": "^1.4.1",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
+        "prosemirror-changeset": "^2.4.1",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-gapcursor": "^1.4.1",
+        "prosemirror-history": "^1.5.0",
+        "prosemirror-inputrules": "^1.5.1",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.11",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.9"
       },
       "funding": {
         "type": "github",
@@ -1168,52 +1098,41 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.5.tgz",
-      "integrity": "sha512-LZ/LYbwH6rnDi5DnRyagkuNsYAVyhM+yJvvz+ZuYA0JkPiTXJV86J5PWSKew8M0gVfMHcNVtKjfQCvViFCeIgw==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.30.1.tgz",
+      "integrity": "sha512-6P2WEp2ZHsx8LV6hQ3K/MB3n39oiVhKESlzh0v+KhK8RR/iKSKGxvTFbi1D/1fo4j3fZf+43PGHjyKXskn9ZmQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tiptap/core": "^3.22.5",
-        "@tiptap/extension-blockquote": "^3.22.5",
-        "@tiptap/extension-bold": "^3.22.5",
-        "@tiptap/extension-bullet-list": "^3.22.5",
-        "@tiptap/extension-code": "^3.22.5",
-        "@tiptap/extension-code-block": "^3.22.5",
-        "@tiptap/extension-document": "^3.22.5",
-        "@tiptap/extension-dropcursor": "^3.22.5",
-        "@tiptap/extension-gapcursor": "^3.22.5",
-        "@tiptap/extension-hard-break": "^3.22.5",
-        "@tiptap/extension-heading": "^3.22.5",
-        "@tiptap/extension-horizontal-rule": "^3.22.5",
-        "@tiptap/extension-italic": "^3.22.5",
-        "@tiptap/extension-link": "^3.22.5",
-        "@tiptap/extension-list": "^3.22.5",
-        "@tiptap/extension-list-item": "^3.22.5",
-        "@tiptap/extension-list-keymap": "^3.22.5",
-        "@tiptap/extension-ordered-list": "^3.22.5",
-        "@tiptap/extension-paragraph": "^3.22.5",
-        "@tiptap/extension-strike": "^3.22.5",
-        "@tiptap/extension-text": "^3.22.5",
-        "@tiptap/extension-underline": "^3.22.5",
-        "@tiptap/extensions": "^3.22.5",
-        "@tiptap/pm": "^3.22.5"
+        "@tiptap/core": "3.30.1",
+        "@tiptap/extension-blockquote": "3.30.1",
+        "@tiptap/extension-bold": "3.30.1",
+        "@tiptap/extension-bullet-list": "3.30.1",
+        "@tiptap/extension-code": "3.30.1",
+        "@tiptap/extension-code-block": "3.30.1",
+        "@tiptap/extension-document": "3.30.1",
+        "@tiptap/extension-dropcursor": "3.30.1",
+        "@tiptap/extension-gapcursor": "3.30.1",
+        "@tiptap/extension-hard-break": "3.30.1",
+        "@tiptap/extension-heading": "3.30.1",
+        "@tiptap/extension-horizontal-rule": "3.30.1",
+        "@tiptap/extension-italic": "3.30.1",
+        "@tiptap/extension-link": "3.30.1",
+        "@tiptap/extension-list": "3.30.1",
+        "@tiptap/extension-list-item": "3.30.1",
+        "@tiptap/extension-list-keymap": "3.30.1",
+        "@tiptap/extension-ordered-list": "3.30.1",
+        "@tiptap/extension-paragraph": "3.30.1",
+        "@tiptap/extension-strike": "3.30.1",
+        "@tiptap/extension-text": "3.30.1",
+        "@tiptap/extension-underline": "3.30.1",
+        "@tiptap/extensions": "3.30.1",
+        "@tiptap/pm": "3.30.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/diff": {
@@ -1232,9 +1151,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1254,1131 +1173,56 @@
       "peer": true
     },
     "node_modules/@umbraco-cms/backoffice": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.3.5.tgz",
-      "integrity": "sha512-8GDjy8if4wFHLT68UWVma1FzDnEGuQtWbg+v2GRLhSpA8FSKJIXgj6d1Hg78enT9cOyN5T6UaiRa9SmNANsTXA==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.6.1.tgz",
+      "integrity": "sha512-l2HDhVhKWcXkJGCIZ/SmxYNyOmRtzMYmBwP8JuRwddPFQ627qtK3YyOJfwW8eXZBmOZQBmL3Iq4XKaJMuzC50w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=22.17.1",
-        "npm": ">=10.9.2"
+        "node": ">=24.13",
+        "npm": ">=11"
       },
       "peerDependencies": {
         "@heximal/expressions": ">=0.1.5 <1.0.0",
-        "@hey-api/openapi-ts": ">=0.85.0 <1.0.0",
+        "@hey-api/openapi-ts": ">=0.85.2 <1.0.0",
         "@microsoft/signalr": "^10.0.0",
-        "@tiptap/core": "^3.16.0",
-        "@tiptap/extension-image": "^3.16.0",
-        "@tiptap/extension-subscript": "^3.16.0",
-        "@tiptap/extension-superscript": "^3.16.0",
-        "@tiptap/extension-table": "^3.16.0",
-        "@tiptap/extension-text-align": "^3.16.0",
-        "@tiptap/extension-text-style": "^3.16.0",
-        "@tiptap/extensions": "^3.16.0",
-        "@tiptap/pm": "^3.16.0",
-        "@tiptap/starter-kit": "^3.16.0",
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/extension-image": "^3.22.3",
+        "@tiptap/extension-subscript": "^3.22.3",
+        "@tiptap/extension-superscript": "^3.22.3",
+        "@tiptap/extension-table": "^3.22.3",
+        "@tiptap/extension-text-align": "^3.22.3",
+        "@tiptap/extension-text-style": "^3.22.3",
+        "@tiptap/extensions": "^3.22.3",
+        "@tiptap/pm": "^3.22.3",
+        "@tiptap/starter-kit": "^3.22.3",
         "@types/diff": "^7.0.2",
-        "@umbraco-ui/uui": "^1.17.2",
-        "@umbraco-ui/uui-css": "^1.17.1",
-        "diff": "^8.0.3",
-        "dompurify": "^3.3.0",
+        "@umbraco-ui/uui": "^2.0.2",
+        "diff": "^9.0.0",
+        "dompurify": "^3.4.1",
         "element-internals-polyfill": "^3.0.2",
         "lit": "^3.3.1",
         "luxon": "^3.7.2",
-        "marked": "^17.0.1",
+        "marked": "^18.0.0",
         "monaco-editor": ">=0.55.1 <1.0.0",
         "rxjs": "^7.8.2",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       }
     },
     "node_modules/@umbraco-ui/uui": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.17.2.tgz",
-      "integrity": "sha512-Wpa69fKWUrMAlUGxJ03vytpYigbOapaenqF6et/Gp2OydAVmYr4rkSnJvkaEqMTSHZnVAGGzf4LDLLBAfkhTVg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-2.0.2.tgz",
+      "integrity": "sha512-OcRJ+l6mr9Yp4y0hCg0Tp38ib+qzednOaZ4yRmx+2YZ4vQ8A5DYpAXFMK1mzorSBlkF6iEIg1DwUl12ieoQBXw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.17.2",
-        "@umbraco-ui/uui-avatar": "1.17.2",
-        "@umbraco-ui/uui-avatar-group": "1.17.2",
-        "@umbraco-ui/uui-badge": "1.17.2",
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-boolean-input": "1.17.2",
-        "@umbraco-ui/uui-box": "1.17.2",
-        "@umbraco-ui/uui-breadcrumbs": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-button-copy-text": "1.17.2",
-        "@umbraco-ui/uui-button-group": "1.17.2",
-        "@umbraco-ui/uui-button-inline-create": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2",
-        "@umbraco-ui/uui-card-block-type": "1.17.2",
-        "@umbraco-ui/uui-card-content-node": "1.17.2",
-        "@umbraco-ui/uui-card-media": "1.17.2",
-        "@umbraco-ui/uui-card-user": "1.17.2",
-        "@umbraco-ui/uui-caret": "1.17.2",
-        "@umbraco-ui/uui-checkbox": "1.17.2",
-        "@umbraco-ui/uui-color-area": "1.17.2",
-        "@umbraco-ui/uui-color-picker": "1.17.2",
-        "@umbraco-ui/uui-color-slider": "1.17.2",
-        "@umbraco-ui/uui-color-swatch": "1.17.2",
-        "@umbraco-ui/uui-color-swatches": "1.17.2",
-        "@umbraco-ui/uui-combobox": "1.17.2",
-        "@umbraco-ui/uui-combobox-list": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2",
-        "@umbraco-ui/uui-dialog": "1.17.2",
-        "@umbraco-ui/uui-dialog-layout": "1.17.2",
-        "@umbraco-ui/uui-file-dropzone": "1.17.2",
-        "@umbraco-ui/uui-file-preview": "1.17.2",
-        "@umbraco-ui/uui-form": "1.17.2",
-        "@umbraco-ui/uui-form-layout-item": "1.17.2",
-        "@umbraco-ui/uui-form-validation-message": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-icon-registry": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2",
-        "@umbraco-ui/uui-input": "1.17.2",
-        "@umbraco-ui/uui-input-file": "1.17.2",
-        "@umbraco-ui/uui-input-lock": "1.17.2",
-        "@umbraco-ui/uui-input-password": "1.17.2",
-        "@umbraco-ui/uui-keyboard-shortcut": "1.17.2",
-        "@umbraco-ui/uui-label": "1.17.2",
-        "@umbraco-ui/uui-loader": "1.17.2",
-        "@umbraco-ui/uui-loader-bar": "1.17.2",
-        "@umbraco-ui/uui-loader-circle": "1.17.2",
-        "@umbraco-ui/uui-menu-item": "1.17.2",
-        "@umbraco-ui/uui-modal": "1.17.2",
-        "@umbraco-ui/uui-pagination": "1.17.2",
-        "@umbraco-ui/uui-popover": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "@umbraco-ui/uui-progress-bar": "1.17.2",
-        "@umbraco-ui/uui-radio": "1.17.2",
-        "@umbraco-ui/uui-range-slider": "1.17.2",
-        "@umbraco-ui/uui-ref": "1.17.2",
-        "@umbraco-ui/uui-ref-list": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2",
-        "@umbraco-ui/uui-ref-node-data-type": "1.17.2",
-        "@umbraco-ui/uui-ref-node-document-type": "1.17.2",
-        "@umbraco-ui/uui-ref-node-form": "1.17.2",
-        "@umbraco-ui/uui-ref-node-member": "1.17.2",
-        "@umbraco-ui/uui-ref-node-package": "1.17.2",
-        "@umbraco-ui/uui-ref-node-user": "1.17.2",
-        "@umbraco-ui/uui-scroll-container": "1.17.2",
-        "@umbraco-ui/uui-select": "1.17.2",
-        "@umbraco-ui/uui-slider": "1.17.2",
-        "@umbraco-ui/uui-symbol-expand": "1.17.2",
-        "@umbraco-ui/uui-symbol-file": "1.17.2",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.17.2",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.17.2",
-        "@umbraco-ui/uui-symbol-folder": "1.17.2",
-        "@umbraco-ui/uui-symbol-lock": "1.17.2",
-        "@umbraco-ui/uui-symbol-more": "1.17.2",
-        "@umbraco-ui/uui-symbol-sort": "1.17.2",
-        "@umbraco-ui/uui-table": "1.17.2",
-        "@umbraco-ui/uui-tabs": "1.17.2",
-        "@umbraco-ui/uui-tag": "1.17.2",
-        "@umbraco-ui/uui-textarea": "1.17.2",
-        "@umbraco-ui/uui-toast-notification": "1.17.2",
-        "@umbraco-ui/uui-toast-notification-container": "1.17.2",
-        "@umbraco-ui/uui-toast-notification-layout": "1.17.2",
-        "@umbraco-ui/uui-toggle": "1.17.2",
-        "@umbraco-ui/uui-visually-hidden": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-action-bar": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.17.2.tgz",
-      "integrity": "sha512-58FCYYVcr/kDx3vCtBNKMUD/Wm9hLSRJ+Vcz7B+PB+Ksj5mHNXtfxEqwZkh8E1CXosrYVvd9IrGjjIo9keQx5w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button-group": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-avatar": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.17.2.tgz",
-      "integrity": "sha512-9tQ7YvHBfQhy30yI0c/+gAGOMGRBlAj06nalAlOeeRE96Gs+qLD4xFfmhdl4+A4QJNube/VvujTOShrlACdfqA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-avatar-group": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.17.2.tgz",
-      "integrity": "sha512-It0ml/h4PWm/Uoy7VdESJEV/xjvEJnC5dQjZlG6I6x+HmpejbJs8/EPNiWiksNff7A6yZ0zHNJOoZjJPTEcGmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.17.2",
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-badge": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.17.2.tgz",
-      "integrity": "sha512-JLbzuWk7lsN2e3wLPxD4+gGTAoufIo+cAjIR+3+UAPY36PXwuUulnypuATLElqL5PPBQssjQmBF/K0o83V2HjQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-base": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.17.2.tgz",
-      "integrity": "sha512-UZkHUY2vdc61t9uq8ey2o4Qpb2aAAQC5HoeBqUu/lEpaWRezHk7QoFIeQrzo3QC2xUa6lSqmSuTYQRWUdFaH2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "lit": ">=2.8.0"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-boolean-input": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.17.2.tgz",
-      "integrity": "sha512-34gdbpSCQRUeLTzh0N+w4GazRbqR4bWAvi5HQe5N/qKrI/5ziQEVQNRaintmxTZ3S6WxxAbF5yaF60UbCW75iA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-box": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.17.2.tgz",
-      "integrity": "sha512-tXBSnb1Gmxub7772SqQvHngbmMkrPzfZ6TorZkNLJlddlNgYJmpoGeFZKGVaJpwCOR+W3O7LcT/juOv+sPvv4A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-breadcrumbs": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.17.2.tgz",
-      "integrity": "sha512-KRFyw7c0OS12zSPFN8A1uCFPdBEshN0SWHMXcZsP4nswjYkj6sJYe6sWUjDETgmgtf9zYK6SzUjI8gyZoFuLFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-responsive-container": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-button": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.17.2.tgz",
-      "integrity": "sha512-F3NO89b3vHOOhWrfM170Z383HsYf9Nji1LxZAedXtAyNzXjIGRKQH5cbiDJBZ8r9J51dVOl0glr23Di4SHiNsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-button-copy-text": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.17.2.tgz",
-      "integrity": "sha512-vbaykS2iQM5Lj1oJpSrkfMErYgeR/hxIsYdpGyl41Xc0XZbQxA6ZhhXuOwKnkALnJX3rr0myhSfzk+xBA1nZ6Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-button-group": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.17.2.tgz",
-      "integrity": "sha512-XvSN8wngvTCPKgIRei1glKiMhBiATFpzNLuc1nJFnDoljlrehzbViwUNtGv+dtxe5XmdEp1cKQB5LW4PesQrZw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-button-inline-create": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.17.2.tgz",
-      "integrity": "sha512-NLzwh0mMOIZSe3mj5bHy1vobSqU7VW/G1ixswngwj2FSBsIxLOZY32pECvXPA8dGfazH2Xl5dIIemyrh8vN4xw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.17.2.tgz",
-      "integrity": "sha512-8WpXK0MU6ycSidpG41wTxWrn8iHR9A/xWZgx2wuol3qF73wakRVR7IdoWxsTAtj7uVg2xp6q19ABZLML+BUG9g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-checkbox": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card-block-type": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.17.2.tgz",
-      "integrity": "sha512-GPuUNj1rjy+HavtzkvF5LEDvYmhN5W7DTRB+5WSpUmX6cyNP/J+LJfx6q0FxOD1DtmLl3/lTLhZxfNe/E2QKsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card-content-node": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.17.2.tgz",
-      "integrity": "sha512-21gwLrvS/A3CuYo0fdD5CLZEil+LehqNk0OY+OwYu07n72O0lQK97BTuwqrDI8IeRhm+xtAof45RiWPBu4ydww==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card-media": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.17.2.tgz",
-      "integrity": "sha512-pOs9DMkdFH00OZlYMfODCgA+BQA8EkTutkTdx1YiucmJUfRt+Lt6pnZjHn+BW0vuo1S69Bn4qXP+1XzbwCREqw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2",
-        "@umbraco-ui/uui-symbol-file": "1.17.2",
-        "@umbraco-ui/uui-symbol-folder": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card-user": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.17.2.tgz",
-      "integrity": "sha512-jnqIMQ66pV1QDMxkDeljbnm+QTSpqyuTu4UIwWtEi2F2z4yIidZ7E5Ii9T1Z2lOW9hxKBuR4DG0LrxIg0ZeniA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.17.2",
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-caret": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.17.2.tgz",
-      "integrity": "sha512-8nDsGmr/K2uYpdKMImofvK9rYvdfLqppLOvXEE2JwzEsFT04LACm14rvTUsYHGKAAOYwCosb/NDm+bPCagJVvA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-checkbox": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.17.2.tgz",
-      "integrity": "sha512-9NTKAdaqMHVnOyX7ya8pJ4hEyIh1p2DciOJCpL8Jy73K2NqsHl5VQLs7YR7LnijlAoJsOXKES0LxcYgfOzDOpA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-boolean-input": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-area": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.17.2.tgz",
-      "integrity": "sha512-4NWt9OoyG81JvifcsrBufhOeJL1CBkmEeSIRms3Rokbsg6imeEJ/e6Ga4AJFauAhsroloxirf7QBfUUQ+lEueg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "colord": "^2.9.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-picker": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.17.2.tgz",
-      "integrity": "sha512-SOpJtZb11gm33WZfRltmoSmRgw7JDsG14GqbBwi4KL556+GLzeNMRPswU4hDCb7e69A1hK8+oBoMIVQwXPB6vw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "colord": "^2.9.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-slider": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.17.2.tgz",
-      "integrity": "sha512-sCygVWQHOw4eOxTl3EpN1/3BF9wLnnBostEWG8Om6EFRoXCb9DMBvh/kTfkF6ZoUIGxPFPAD1hpXF/ANtUka2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-swatch": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.17.2.tgz",
-      "integrity": "sha512-hMAUzXDCNR2H4yPZDJmUig4kQt9xL/gH7ghcazYxeY7vuLLnGucxljTfTiZISqdjeQpheSt807gz9XnWDLY9Ng==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2",
-        "colord": "^2.9.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-swatches": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.17.2.tgz",
-      "integrity": "sha512-M0flkhmZvcx2oYcn5ffK2z/ByKMEjALd4fy0BQ4Yzz4OerWFliojkXfv1Dc27Lyzl+UKJFf7LK61UY/MA2Z42Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-color-swatch": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-combobox": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.17.2.tgz",
-      "integrity": "sha512-X3PqQzpkvj8mfbjb/ntLgLPIWTy6Mvw2lIyPcOCGN6eg5CAai51qZjt/S9KSg5c//UQings3i//G/ycyIBKBEg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-combobox-list": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "@umbraco-ui/uui-scroll-container": "1.17.2",
-        "@umbraco-ui/uui-symbol-expand": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-combobox-list": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.17.2.tgz",
-      "integrity": "sha512-EPVQfG692sS9XT+qn6QU4dUbGTgQzneF4sHcmbm6gyHfutW3pv0xCa43RspoXK8iMjNdrHEqZqW1bpSWIhp3fA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-css": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.17.2.tgz",
-      "integrity": "sha512-+g+Za0i2ZUZTf9C5GOmJ6olJxH3J181GIB79mg7soAUG/ofMTOw0uKR34sG9SUXG2+qoenzWoF9B5qUjydJOeQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "lit": ">=2.8.0"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-dialog": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.17.2.tgz",
-      "integrity": "sha512-6f89YWRvYUHcLLf5yZ5UXT36bPuRTBRt6AqCREy2NTox1M0e2fU4+T61UrEy8XjcF25+8Ylc+ETb7KCHeUb1FA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-dialog-layout": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.17.2.tgz",
-      "integrity": "sha512-sBeFz6UZUtArP9/bnykuZVT1S4oYK9JjIOm36Z0Wurw893aPAHiNCq9hrCaZF8xmS+ZLrqSmkNhZ22slKWkw6Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-file-dropzone": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.17.2.tgz",
-      "integrity": "sha512-1JnURFHBHpO/QCEaMXJOj1xj1ttOPjn7twxOlZeJgpZoKDepqxRCW2UX9vqwop+ge3LWoMMvSTxa6GNHBs34gA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-file-preview": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.17.2.tgz",
-      "integrity": "sha512-L+w5mMIcgwNlWA6/SAWoU9bpEbzEB/reVWALWOAScv1Lvqo/HmjjxHMclFJzm+6DSM3euH53X2zOHmAp1oUnOA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-symbol-file": "1.17.2",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.17.2",
-        "@umbraco-ui/uui-symbol-folder": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-form": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.17.2.tgz",
-      "integrity": "sha512-39ynzYgPdhpDSyVxpBJBDPrRmGKfnhcHVrMTcv5ITUnmsHizqd4tK5+gdf5tcHXrAxb+AWHEufwjjNcRHdl/Ww==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-form-layout-item": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.17.2.tgz",
-      "integrity": "sha512-FLDd+Y5x/6L8cHAPzicX/e4mxH/tx2DBWuzXV4MeNp8eRS132xCBM9laI+1/dnBjCzYzJuVd8ibmFO0+Yjf8Uw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-form-validation-message": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-form-validation-message": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.17.2.tgz",
-      "integrity": "sha512-AWI9WC7wZW7qgrZ1EUnzCt40KdB1iiJBPwUnyffm4L3MsGyUVEQYYO96v/y04PGFr6DUlcDlAerhSqcsaJK7Kw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-icon": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.17.2.tgz",
-      "integrity": "sha512-7WmGW3nn7IeL5nMZtIYaSWaV0AeBoE90rfAqjbK/fHzyDtgM1gsokXhCtEQH9VLnjFfs02bXF+Xlw+ZEP3+p5A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-icon-registry": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.17.2.tgz",
-      "integrity": "sha512-P5ypiDGswu0uPhyVcltuFHLkVax9DURUgz2jgsuNDkLJh4BW34TFTHu7c7XKVRzVMIb7356SxO8B+q6fYEPNqA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-icon-registry-essential": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.17.2.tgz",
-      "integrity": "sha512-vfumKb+H6bT1tTMKOHK/rZW4QDBxzANzAqvAqpeB7n0EEd5j+82tSv15DDZDlyXHvMNUnoBrI+zNpCYsDbNV5Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon-registry": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-input": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.17.2.tgz",
-      "integrity": "sha512-8aoM58rkLEYdQljWHBA8hgwEqnjeVXzFfMdO+QuwgLpKEBZij/33iWBl2j/IGmxByiFcxSvsbzEFhXHNRlU4Jg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-input-file": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.17.2.tgz",
-      "integrity": "sha512-bWwp6KkMDuMvIjmRh9WOXBdVyaEdcCyvdqBYss+BrXEeHF+Qs9SMHK4giLGAosYIWxzctmT9tUZfUpuJu8QP0w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.17.2",
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-file-dropzone": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-input-lock": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.17.2.tgz",
-      "integrity": "sha512-Vu6TViMQuERTqx5kd518aujwrtztxbErHqAw1VNl6aT1q4GoADLtVyxnFYMhtg6mokUJL4ZxTxMuiAKVLjJM9Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-input": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-input-password": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.17.2.tgz",
-      "integrity": "sha512-a7hLURjTwNpuqepeBAWOGyKmvuy9dPXs2YdxakaoUsia486gjerIZOKv29vQ83Uw5EivdvYZMuFGM4TngQZ26g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2",
-        "@umbraco-ui/uui-input": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-keyboard-shortcut": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.17.2.tgz",
-      "integrity": "sha512-2XXU9p80iGJVsHvIDA4u/IsRTD1psW5yEmWZbUJI0nouhGfoBGjF6mgo2AYEVczrP90JBvWJhhunCe1JfPK9WQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-label": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.17.2.tgz",
-      "integrity": "sha512-xbvmKU2zGNaIo1Zn7cOy6EmidxzFYoihsEkbOrMBItbebhZcZc+MUHuEFr+brgMHowk0CtUJnITjpSsow/4BUA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-loader": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.17.2.tgz",
-      "integrity": "sha512-wnR47k7zbDG4upQmucTuaNyyFR9VKVoBiGLTGTITNvK66G+EpwL96xwd3YqbJx4oRXQEkCyorlbE8oxY2B9Xig==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-loader-bar": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.17.2.tgz",
-      "integrity": "sha512-KHe1W3pHaJ5SX+D1TcLOYti5Z+RuVd5o0Wm4XONvWN7DZ/cs1E8pO0mvgJYLZbZv989u9RwhH4cuOCxTByt4ew==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-loader-circle": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.17.2.tgz",
-      "integrity": "sha512-pYXvXEhm+oNWDNc2QKNDK9nILAPnegyTkQEdhBumF5RqISCZT0OXufhP8//Ez7Ao/c84I0Jv/jVNqgmDIxg0wg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-menu-item": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.17.2.tgz",
-      "integrity": "sha512-aDAp61Z/3/1qQN34phkekYHH+IpCldNp26VF4PZBb7YlpxYfbEbO/xKqxkRQYvrEeq1TNpDQF8vhmbJn0BdmaA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-loader-bar": "1.17.2",
-        "@umbraco-ui/uui-symbol-expand": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-modal": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.17.2.tgz",
-      "integrity": "sha512-IFrpRuFrouYo8DqrK1DyrGWkmHbf8sP5OQjCqYfmZ15AwqPt791h4uwTponrjJVOwFwy2sq3mZPAR7ob/V/6DA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-pagination": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.17.2.tgz",
-      "integrity": "sha512-ECWL/9p5IDBf8EKES9pG8QL+5hNNagmtE+3hCZH2x+D3yW28fcMh8SW5QtBgfebBNXdZAp4lrxcTtUyFA6By+g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-button-group": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-popover": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.17.2.tgz",
-      "integrity": "sha512-Pqh7k+ZpEGGMdpRbNO6+6p9ggZ/wtZs9MyylB6/56PLlIepVqhGBqlJbJ6+z4Ph4S752btMmqz04GdJ09yaZuA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-popover-container": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.17.2.tgz",
-      "integrity": "sha512-lCzQFUo3QESYbKkk69KJMC5cmJ4VS3hEPdSRATzBqEDtzj/h6aEdrww1EOAOOLCw+JgNd0wKS/+sp3RCmiZxeg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-progress-bar": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.17.2.tgz",
-      "integrity": "sha512-I/T0K4l9QcWJGSOI4G7Zr4uMz/UjgM4nA7ebjDc2cgY5hLcefknFS5LSGWjPxTe+R9OIFFkFXLvQqlFZnH2AcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-radio": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.17.2.tgz",
-      "integrity": "sha512-iDvaEUltTAAwqRYY/8bIRyfN2j9vGc3CpZlWNe5nC2QOD+tPVEq5MWyg3N3Gbx6K9bkg+DrIAblk2Mc8YFEHAg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-range-slider": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.17.2.tgz",
-      "integrity": "sha512-mjgxoHQnkIKrYv2I1mjESgSy8yPZOSHoFURoeh9fc3G0bnkoTbNwLMKMWL3NSQObHo+TpK6djSaiXLB1vIAwJA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.17.2.tgz",
-      "integrity": "sha512-SWyS/sduAw8vmesw0Sm7jsblhZ7i9vckOAzCQs2Hrbtssgq1EZ0PkkICS2Vg3rVnR0HSYt8T2s7Fy7yjK4MYHQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-list": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.17.2.tgz",
-      "integrity": "sha512-LzKcN94JSpbH0YmpBj9fl58WdwFeGbovFhLBInUcLOX8WqK0E+lNdBLRya7l8KYIKmhQKE3TUbqiN6Qcwhr2mA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.17.2.tgz",
-      "integrity": "sha512-C6fqnEDYlGlqF3gEQFPy8908LcZLzPqhVHC1p6AXXNkTPnnKqSAPxRPKRUk7XUoQSYFDXfCzFnlyKdlpWSIJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-ref": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-data-type": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.17.2.tgz",
-      "integrity": "sha512-nEEKv8TYjueZprnfFg9sW1u/Y3Z8X+IqGPWRg0Hx+gLLKmOPHbvlYUIB8M4Q4G61XlcY8dfw+TDZ8kxTekmEWA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-document-type": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.17.2.tgz",
-      "integrity": "sha512-w+qe2g9FDUTHLzRStffDOoudHUeWw+RXgoOLtI8f5xktbuKDcpz6qiIOIvTO9ipfy9vpbU/WiUr7OSBVdxGSaQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-form": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.17.2.tgz",
-      "integrity": "sha512-056oxK3ffKIERFfYgYG+Ies4S75TPEdME1WXYYG6p9QzfZ06Y0VaNCQbzoHwS8CcbtO5/m2C3BXB6b0l26lDkg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-member": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.17.2.tgz",
-      "integrity": "sha512-oeWQHu7u1/xK9IOnm5YMceLPzfGsuIsYyU+UJRJkwIiWYT155gosdGoxCz/AkMr58NBT223ES1UKFCZJaRFTGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-package": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.17.2.tgz",
-      "integrity": "sha512-3hWJvvOCLYOZNt0fMdH8atwQrrPF6eM3ftZcxPCch8/cW3AQ5jWIpYnP/s4hRhNFCWKkKW7Y5l/vBbT2LKEtUA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-user": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.17.2.tgz",
-      "integrity": "sha512-9KdVhHe10UXN3RnZJ5pMT1WBpbKZxdOREpSq0tjN+o1EYEqnSw9EM5RrCVZx/OsljJzgzFNZRkhEr+zlmsr30A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-responsive-container": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.17.2.tgz",
-      "integrity": "sha512-eH4x9JpJyw7/IPyqAE6EpNq4jp7OlMkHlirnAMJZsp0v6Ou/NhuIossFaxla/OMX4PtulGL1WsoeIX3D4B7fQQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-button-group": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "@umbraco-ui/uui-symbol-more": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-scroll-container": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.17.2.tgz",
-      "integrity": "sha512-ZdpJINTnguUIGFkjrm/6MPl2KrAai3UrrVYBOjx2CBvYxnfAsu/zicQ54kIoqsoYXDnIx/9xCKLodKLlHhz6LA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-select": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.17.2.tgz",
-      "integrity": "sha512-IhocB11XsXFDI5hcEEXJJSeUfYZLKwqBWMh2TemFKEsafzFkGvmOEqppxrZD1J3wcWZAXODoSLoURcKIafQqLA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-slider": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.17.2.tgz",
-      "integrity": "sha512-ewO5NYZptQUMJRkO1MFH5RdwtjFEpaVtLBbBAfmV7CevY+kY7q6KeITlBZW8J8alMM3lNF8HGg0ccTg0gJ7I8g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-expand": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.17.2.tgz",
-      "integrity": "sha512-qOee3XhHOu7QsbBUp1TOGHBpiE+oj+BY8Eh/lC8cDkwGc9yTndM4SU+YX/HN1qcLfIvqiAu3TnX53/KOjyKdzw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-file": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.17.2.tgz",
-      "integrity": "sha512-flDs3M9h+uAp8WJPXLLHNR9nLqDLU1TRTyCS3L7OYJz81/WuAwlvt3okezTJEC5dgtNH4guoIXJbHsY7XMVYNw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-file-dropzone": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.17.2.tgz",
-      "integrity": "sha512-WwG5o5Gm1j3UKUYMCQW3PM2sIUHOecmxq1FQETyhUoPFJKRTgsP2J261pWk/2S+VbEEtKB1v0MlZWSdz60D3Ww==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-file-thumbnail": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.17.2.tgz",
-      "integrity": "sha512-IF4fcz4wGFy5qpi0hE5sWyTl5gnw0wrnDaCZapi0Xfie6le6m7CgJCz9dp8CWPQFl01UDWr/1eR6C0XEO0FlNQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-folder": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.17.2.tgz",
-      "integrity": "sha512-08ma38W6h805EiHELsGojS+Q3CoBoVKoR5yIY5f1/Pb/a2etCcTVRmKQuAlUD1vc9sSBdJBsoNOeczZPy7xCYQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-lock": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.17.2.tgz",
-      "integrity": "sha512-DJkcQs519aSlezLMxTl/hf0gMAg1GVA6QiQhX6hOEARV4C6/TUpwDpXK/j9/5M9mtqjgPfDG97+SJi0iVgcsew==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-more": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.17.2.tgz",
-      "integrity": "sha512-7F49+dHg5l2a4Ftv0aZAkirZZlkhKDLjyupAX+/FvSiv+cJbmKwgmmre4n2fShWkxeJ4RKh/AT1MR1l8GzxH4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-sort": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.17.2.tgz",
-      "integrity": "sha512-7k9ckDBrBf5O3UNveAIL2KIzXSZq8CE3C3HTn2k0EPjK0pZZXGYCc0u8fU8JuxNxX8GA3N8IeVOpM3OaHKa8vg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-table": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.17.2.tgz",
-      "integrity": "sha512-pjVK3gZ00ucXzsmB32EaxRXrxXbFSP+trcZm3qiFcD6cK2wLx6HMtcVxHgHGQR+OYJ/0v7Q7KvIBepC7gdA7fQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-tabs": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.17.2.tgz",
-      "integrity": "sha512-5GjxdMTYbAsDcIhJqAfsdypkE7yHvYXrsSc6vTDldB3mn9yA3BxpgzAijWnjptugMhG/a9L7myODp3kt4k4Z/w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "@umbraco-ui/uui-symbol-more": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-tag": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.17.2.tgz",
-      "integrity": "sha512-LCwC3ZrMu1A624VZz1oNGzd1SQ5UImEH+hpptb0BunEOQ3JkOOiwNKJny/Sfc/Z+GAWFnrOiRxNQPBzgAWXFJw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-textarea": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.17.2.tgz",
-      "integrity": "sha512-6ZdTsIcSAPOT7K+YxLowEmQpRu330Vawqp7vuegC7VgmqFZerIGJZhPcJbLnUJJ5co8IH2IWj5DYyMLOx3Eqaw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-toast-notification": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.17.2.tgz",
-      "integrity": "sha512-bu5JTbgiJje6b5FTXNNjefaXhDZNiBeUaUgGDlG6c8q7Q/fdm5fqwcaOKQog2hc0dZn+thqeVHRZwFBrvsgeYg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-toast-notification-container": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.17.2.tgz",
-      "integrity": "sha512-6wrHbpd1C+vHJT4Y1rVh09+dPpHFpQslcVvrh9Jk4U2QJiAph6UURj6QbxKutQrYRH6snq2Nue4vHq++LYNS8w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-toast-notification": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-toast-notification-layout": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.17.2.tgz",
-      "integrity": "sha512-9XSmjrwXzy6dc08f36bqcUaPUkKDApjlwF+CpjUgwrLtdGVjOrixNEQnj8oFSxQEas01VzO0rhH+mYzYNC6fwQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-toggle": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.17.2.tgz",
-      "integrity": "sha512-brc2pKPd7j5TKOFKdbkRaZQah03XYGAPlO7j3IkdM2AXQRc0BaVseD/xHb8FeENzTYLL4XL7rseYkn16GbBhFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-boolean-input": "1.17.2"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-visually-hidden": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.17.2.tgz",
-      "integrity": "sha512-OxWccGa7VGjr1nvK0f6F6+DcqVYaW8QN/83Sg81eaKSg88Td15un3tws9w0BPjoaMYWFbvZXk3uofDs1V7vDrw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "culori": "^4.0.2",
+        "lit": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=24.13",
+        "npm": ">=11"
       }
     },
     "node_modules/abort-controller": {
@@ -2396,9 +1240,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2446,6 +1290,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0",
+      "peer": true
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2457,16 +1309,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bundle-name": {
@@ -2544,14 +1396,6 @@
         "color-support": "bin.js"
       }
     },
-    "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2584,6 +1428,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/culori": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/culori/-/culori-4.0.2.tgz",
+      "integrity": "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/debug": {
@@ -2684,9 +1539,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -2695,9 +1550,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -2741,18 +1596,21 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2774,7 +1632,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2915,9 +1773,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -3018,9 +1876,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -3054,9 +1912,9 @@
       }
     },
     "node_modules/giget": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
-      "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3196,14 +2054,28 @@
       "license": "ISC"
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-buffer": {
@@ -3252,9 +2124,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -3268,23 +2140,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -3303,9 +2175,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -3324,9 +2196,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -3345,9 +2217,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -3366,9 +2238,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -3387,9 +2259,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -3408,9 +2280,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -3429,9 +2301,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -3450,9 +2322,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -3471,9 +2343,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -3492,9 +2364,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -3513,17 +2385,17 @@
       }
     },
     "node_modules/linkifyjs": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/lit": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -3547,9 +2419,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
-      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -3585,9 +2457,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
-      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3599,13 +2471,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3615,21 +2487,21 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "3.4.8",
         "marked": "14.0.0"
       }
     },
     "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -3659,9 +2531,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3838,9 +2710,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3864,9 +2736,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3884,7 +2756,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3928,9 +2800,9 @@
       }
     },
     "node_modules/prosemirror-commands": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
-      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
+      "integrity": "sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3941,9 +2813,9 @@
       }
     },
     "node_modules/prosemirror-dropcursor": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
-      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+      "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3981,6 +2853,18 @@
         "rope-sequence": "^1.3.0"
       }
     },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
     "node_modules/prosemirror-keymap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
@@ -3994,9 +2878,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "version": "1.25.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+      "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4057,14 +2941,14 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.41.8",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
-      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+      "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-model": "^1.20.0",
+        "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
@@ -4114,9 +2998,9 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4148,13 +3032,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.144.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -4164,21 +3048,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
       }
     },
     "node_modules/rope-sequence": {
@@ -4316,7 +3199,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4379,9 +3263,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
-      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -4394,16 +3278,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -4420,7 +3304,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -4526,9 +3410,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4564,23 +3448,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/Diplo.GodMode/Client/src/elements/godmode-element-type-usage-browser.element.ts
+++ b/Diplo.GodMode/Client/src/elements/godmode-element-type-usage-browser.element.ts
@@ -25,12 +25,14 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
         void this._load();
     }
 
-    private async _load() {
+    private async _load(refresh = false) {
         this._loading = true;
         try {
             const status = await godmodeGet<ElementTypeUsageStatus>("element-type-usage/status");
             this._status = status;
-            this._items = status.isSupported ? await godmodeGet<ElementTypeUsageSummary[]>("element-type-usage") : [];
+            this._items = status.isSupported
+                ? await godmodeGet<ElementTypeUsageSummary[]>("element-type-usage", refresh ? { refresh: true } : undefined)
+                : [];
         } finally {
             this._loading = false;
         }
@@ -90,12 +92,16 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
     }
 
     override render() {
+        const description = this._status?.libraryFeatureAvailable
+            ? "Browse stored and configured block usage, Library Items and Element Picker references."
+            : "Browse stored block occurrences plus Block List, Block Grid and Rich Text configuration references.";
+
         return html`
             <godmode-page
                 heading="Element Type Usage"
-                description="Browse Element Type usage across Block Lists, Block Grids, Library Items and Element Pickers."
+                description=${description}
                 show-reload
-                @reload=${() => void this._load()}
+                @reload=${() => void this._load(true)}
             >
                 ${this._loading ? html`<uui-loader></uui-loader>` : this._renderContent()}
             </godmode-page>
@@ -116,14 +122,6 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
         const totalPages = Math.max(1, Math.ceil(results.length / this._pageSize));
 
         return html`
-            ${this._status && !this._status.libraryFeatureAvailable
-                ? html`
-                      <uui-box class="notice">
-                          <p><uui-icon name="icon-info"></uui-icon> ${this._status.message}</p>
-                      </uui-box>
-                  `
-                : ""}
-
             <uui-box>
                 <div class="filters">
                     <div>
@@ -156,6 +154,13 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
                 </div>
             </uui-box>
 
+            <div class="usage-disclaimer" role="note">
+                <umb-icon name="icon-alert" aria-hidden="true"></umb-icon>
+                <p>
+                    <strong>Before deleting:</strong> God Mode might be omniscient, but usage detection isn't infallible. A count of zero doesn't guarantee that an Element Type is unused, so please verify it before deletion.
+                </p>
+            </div>
+
             <p class="results"><strong>${results.length}</strong> / <strong>${this._items.length}</strong></p>
 
             <uui-table @sort-change=${this._onSortChange}>
@@ -164,8 +169,13 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
                     <godmode-sort-header column="usageCount" .sort=${this._sort}>Usage Count</godmode-sort-header>
                     <godmode-sort-header column="contentUses" .sort=${this._sort}>Content Uses</godmode-sort-header>
                     <godmode-sort-header column="settingsUses" .sort=${this._sort}>Settings Uses</godmode-sort-header>
-                    <godmode-sort-header column="libraryItems" .sort=${this._sort}>Library Items</godmode-sort-header>
-                    <godmode-sort-header column="elementPickerUses" .sort=${this._sort}>Element Picker Uses</godmode-sort-header>
+                    <godmode-sort-header column="configuredUses" .sort=${this._sort}>Configured Uses</godmode-sort-header>
+                    ${this._status?.libraryFeatureAvailable
+                        ? html`
+                              <godmode-sort-header column="libraryItems" .sort=${this._sort}>Library Items</godmode-sort-header>
+                              <godmode-sort-header column="elementPickerUses" .sort=${this._sort}>Element Picker Uses</godmode-sort-header>
+                          `
+                        : ""}
                     <uui-table-head-cell>Actions</uui-table-head-cell>
                 </uui-table-head>
                 ${pageResults.map(
@@ -173,10 +183,11 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
                         <uui-table-row>
                             <uui-table-cell>
                                 <a
+                                    class="element-type-link"
                                     href=${editUrl("documentType", item.elementTypeKey)}
                                     @click=${(e: Event) => openEditorModal(this, "documentType", item.elementTypeKey, e)}
                                 >
-                                    ${item.icon ? html`<uui-icon name=${item.icon}></uui-icon>` : ""}
+                                    <umb-icon name=${item.icon || "icon-document"}></umb-icon>
                                     <strong>${item.elementTypeName}</strong>
                                 </a>
                                 <div><code>${item.elementTypeAlias}</code></div>
@@ -186,8 +197,13 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
                             </uui-table-cell>
                             <uui-table-cell>${item.contentUses}</uui-table-cell>
                             <uui-table-cell>${item.settingsUses}</uui-table-cell>
-                            <uui-table-cell>${item.libraryItems}</uui-table-cell>
-                            <uui-table-cell>${item.elementPickerUses}</uui-table-cell>
+                            <uui-table-cell>${item.configuredUses}</uui-table-cell>
+                            ${this._status?.libraryFeatureAvailable
+                                ? html`
+                                      <uui-table-cell>${item.libraryItems}</uui-table-cell>
+                                      <uui-table-cell>${item.elementPickerUses}</uui-table-cell>
+                                  `
+                                : ""}
                             <uui-table-cell class="action-cell">
                                 <uui-button compact look="secondary" label="Details" @click=${(e: Event) => this._openDetail(item, e)}>
                                     Details
@@ -226,6 +242,24 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
             margin: var(--uui-size-space-3) 0;
             color: var(--uui-color-text-alt);
         }
+        .usage-disclaimer {
+            display: flex;
+            align-items: flex-start;
+            gap: var(--uui-size-space-3);
+            margin-top: var(--uui-size-space-4);
+            padding: var(--uui-size-space-4);
+            border-left: 3px solid var(--uui-color-warning);
+            background: var(--uui-color-surface-alt);
+        }
+        .usage-disclaimer umb-icon {
+            flex: 0 0 auto;
+            margin-top: 0.15em;
+            color: var(--uui-color-warning-emphasis);
+            font-size: var(--uui-type-h5-size);
+        }
+        .usage-disclaimer p {
+            margin: 0;
+        }
         a {
             color: var(--uui-color-interactive);
             text-decoration: none;
@@ -233,15 +267,14 @@ export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitEl
         a:hover {
             text-decoration: underline;
         }
-        .notice {
-            margin-bottom: var(--uui-size-space-4);
-        }
-        .notice p {
-            display: flex;
+        .element-type-link {
+            display: inline-flex;
             align-items: center;
             gap: var(--uui-size-space-2);
-            margin: 0;
-            color: var(--uui-color-text-alt);
+        }
+        .element-type-link umb-icon {
+            flex: 0 0 auto;
+            font-size: var(--uui-type-h5-size);
         }
         .zero {
             color: var(--uui-color-warning-emphasis);

--- a/Diplo.GodMode/Client/src/elements/godmode-element-type-usage-browser.element.ts
+++ b/Diplo.GodMode/Client/src/elements/godmode-element-type-usage-browser.element.ts
@@ -1,0 +1,258 @@
+import { LitElement, css, customElement, html, state } from "@umbraco-cms/backoffice/external/lit";
+import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
+import { godmodeGet } from "../api/client";
+import "../shared";
+import type { ElementTypeUsageStatus, ElementTypeUsageSummary } from "../shared/types";
+import { applySort, toggleSort, type SortState } from "../shared/sort";
+import { editUrl, openEditorModal } from "../shared/edit-links";
+import { openElementTypeUsageModal } from "../shared/element-type-usage-modal";
+
+type TriState = "any" | "yes" | "no";
+
+@customElement("godmode-element-type-usage-browser")
+export class GodModeElementTypeUsageBrowserElement extends UmbElementMixin(LitElement) {
+    @state() private _status: ElementTypeUsageStatus | null = null;
+    @state() private _items: ElementTypeUsageSummary[] = [];
+    @state() private _loading = true;
+    @state() private _search = "";
+    @state() private _usedFilter: TriState = "any";
+    @state() private _sort: SortState = { column: "elementTypeName", reverse: false };
+    @state() private _currentPage = 1;
+    @state() private _pageSize = 25;
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        void this._load();
+    }
+
+    private async _load() {
+        this._loading = true;
+        try {
+            const status = await godmodeGet<ElementTypeUsageStatus>("element-type-usage/status");
+            this._status = status;
+            this._items = status.isSupported ? await godmodeGet<ElementTypeUsageSummary[]>("element-type-usage") : [];
+        } finally {
+            this._loading = false;
+        }
+    }
+
+    private _filtered(): ElementTypeUsageSummary[] {
+        const q = this._search.trim().toLowerCase();
+        const used = this._usedFilter;
+
+        const matched = this._items.filter((item) => {
+            if (q) {
+                const hit = item.elementTypeName.toLowerCase().includes(q) || item.elementTypeAlias.toLowerCase().includes(q);
+                if (!hit) return false;
+            }
+            if (used === "yes" && item.usageCount === 0) return false;
+            if (used === "no" && item.usageCount !== 0) return false;
+            return true;
+        });
+
+        return applySort(matched as unknown as Array<Record<string, unknown>>, this._sort) as unknown as ElementTypeUsageSummary[];
+    }
+
+    private _onSortChange = (e: CustomEvent<string>) => {
+        this._sort = toggleSort(this._sort, e.detail);
+        this._currentPage = 1;
+    };
+
+    private _onPageChange = (e: CustomEvent<number>) => {
+        this._currentPage = e.detail;
+    };
+
+    private _onSearchChange = (e: Event) => {
+        this._search = (e.target as HTMLInputElement).value;
+        this._currentPage = 1;
+    };
+
+    private _onUsedFilterChange = (e: Event) => {
+        this._usedFilter = (e.target as unknown as { value: string }).value as TriState;
+        this._currentPage = 1;
+    };
+
+    private _pageSlice(results: ElementTypeUsageSummary[]): ElementTypeUsageSummary[] {
+        const start = (this._currentPage - 1) * this._pageSize;
+        return results.slice(start, start + this._pageSize);
+    }
+
+    private _openDetail(item: ElementTypeUsageSummary, e: Event) {
+        openElementTypeUsageModal(
+            this,
+            {
+                elementTypeKey: item.elementTypeKey,
+                elementTypeName: item.elementTypeName,
+                elementTypeAlias: item.elementTypeAlias
+            },
+            e
+        );
+    }
+
+    override render() {
+        return html`
+            <godmode-page
+                heading="Element Type Usage"
+                description="Browse Element Type usage across Block Lists, Block Grids, Library Items and Element Pickers."
+                show-reload
+                @reload=${() => void this._load()}
+            >
+                ${this._loading ? html`<uui-loader></uui-loader>` : this._renderContent()}
+            </godmode-page>
+        `;
+    }
+
+    private _renderContent() {
+        if (this._status && !this._status.isSupported) {
+            return html`
+                <uui-box headline="Not available">
+                    <p>${this._status.message}</p>
+                </uui-box>
+            `;
+        }
+
+        const results = this._filtered();
+        const pageResults = this._pageSlice(results);
+        const totalPages = Math.max(1, Math.ceil(results.length / this._pageSize));
+
+        return html`
+            ${this._status && !this._status.libraryFeatureAvailable
+                ? html`
+                      <uui-box class="notice">
+                          <p><uui-icon name="icon-info"></uui-icon> ${this._status.message}</p>
+                      </uui-box>
+                  `
+                : ""}
+
+            <uui-box>
+                <div class="filters">
+                    <div>
+                        <label for="search">Search</label>
+                        <uui-input
+                            id="search"
+                            type="search"
+                            autocomplete="off"
+                            autocorrect="off"
+                            autocapitalize="off"
+                            spellcheck="false"
+                            placeholder="Filter by name or alias"
+                            .value=${this._search}
+                            @input=${this._onSearchChange}
+                        ></uui-input>
+                    </div>
+                    <div>
+                        <label for="used">Usage</label>
+                        <uui-select
+                            id="used"
+                            label="Usage"
+                            .options=${[
+                                { name: "Any", value: "any", selected: this._usedFilter === "any" },
+                                { name: "Used", value: "yes", selected: this._usedFilter === "yes" },
+                                { name: "Unused", value: "no", selected: this._usedFilter === "no" }
+                            ]}
+                            @change=${this._onUsedFilterChange}
+                        ></uui-select>
+                    </div>
+                </div>
+            </uui-box>
+
+            <p class="results"><strong>${results.length}</strong> / <strong>${this._items.length}</strong></p>
+
+            <uui-table @sort-change=${this._onSortChange}>
+                <uui-table-head>
+                    <godmode-sort-header column="elementTypeName" .sort=${this._sort}>Element Type</godmode-sort-header>
+                    <godmode-sort-header column="usageCount" .sort=${this._sort}>Usage Count</godmode-sort-header>
+                    <godmode-sort-header column="contentUses" .sort=${this._sort}>Content Uses</godmode-sort-header>
+                    <godmode-sort-header column="settingsUses" .sort=${this._sort}>Settings Uses</godmode-sort-header>
+                    <godmode-sort-header column="libraryItems" .sort=${this._sort}>Library Items</godmode-sort-header>
+                    <godmode-sort-header column="elementPickerUses" .sort=${this._sort}>Element Picker Uses</godmode-sort-header>
+                    <uui-table-head-cell>Actions</uui-table-head-cell>
+                </uui-table-head>
+                ${pageResults.map(
+                    (item) => html`
+                        <uui-table-row>
+                            <uui-table-cell>
+                                <a
+                                    href=${editUrl("documentType", item.elementTypeKey)}
+                                    @click=${(e: Event) => openEditorModal(this, "documentType", item.elementTypeKey, e)}
+                                >
+                                    ${item.icon ? html`<uui-icon name=${item.icon}></uui-icon>` : ""}
+                                    <strong>${item.elementTypeName}</strong>
+                                </a>
+                                <div><code>${item.elementTypeAlias}</code></div>
+                            </uui-table-cell>
+                            <uui-table-cell>
+                                <strong class=${item.usageCount === 0 ? "zero" : ""}>${item.usageCount}</strong>
+                            </uui-table-cell>
+                            <uui-table-cell>${item.contentUses}</uui-table-cell>
+                            <uui-table-cell>${item.settingsUses}</uui-table-cell>
+                            <uui-table-cell>${item.libraryItems}</uui-table-cell>
+                            <uui-table-cell>${item.elementPickerUses}</uui-table-cell>
+                            <uui-table-cell class="action-cell">
+                                <uui-button compact look="secondary" label="Details" @click=${(e: Event) => this._openDetail(item, e)}>
+                                    Details
+                                </uui-button>
+                            </uui-table-cell>
+                        </uui-table-row>
+                    `
+                )}
+            </uui-table>
+
+            <godmode-pager
+                .currentPage=${this._currentPage}
+                .totalPages=${totalPages}
+                .totalItems=${results.length}
+                @page-change=${this._onPageChange}
+            ></godmode-pager>
+        `;
+    }
+
+    static override styles = css`
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: var(--uui-size-space-1);
+        }
+        .filters {
+            display: grid;
+            grid-template-columns: minmax(220px, 2fr) minmax(140px, 1fr);
+            gap: var(--uui-size-space-4);
+        }
+        .filters uui-input,
+        .filters uui-select {
+            width: 100%;
+        }
+        .results {
+            margin: var(--uui-size-space-3) 0;
+            color: var(--uui-color-text-alt);
+        }
+        a {
+            color: var(--uui-color-interactive);
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .notice {
+            margin-bottom: var(--uui-size-space-4);
+        }
+        .notice p {
+            display: flex;
+            align-items: center;
+            gap: var(--uui-size-space-2);
+            margin: 0;
+            color: var(--uui-color-text-alt);
+        }
+        .zero {
+            color: var(--uui-color-warning-emphasis);
+        }
+    `;
+}
+
+export default GodModeElementTypeUsageBrowserElement;
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "godmode-element-type-usage-browser": GodModeElementTypeUsageBrowserElement;
+    }
+}

--- a/Diplo.GodMode/Client/src/elements/godmode-element-type-usage-modal.element.ts
+++ b/Diplo.GodMode/Client/src/elements/godmode-element-type-usage-modal.element.ts
@@ -1,0 +1,239 @@
+import { LitElement, css, customElement, html, property, state } from "@umbraco-cms/backoffice/external/lit";
+import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
+import { godmodeGet } from "../api/client";
+import type { ElementTypeUsageDetail, ElementTypeUsageEntityType, ElementTypeUsageSourceType } from "../shared/types";
+import type { GodModeElementTypeUsageModalData } from "../shared/element-type-usage-modal";
+import { editUrl } from "../shared/edit-links";
+import { truncate } from "../shared/format";
+import "../shared";
+
+const SOURCE_GROUPS: Array<{ sourceTypes: ElementTypeUsageSourceType[]; heading: string; description: string }> = [
+    {
+        sourceTypes: ["BlockContent"],
+        heading: "Block Content",
+        description: "Embedded as content in a Block List / Block Grid property."
+    },
+    {
+        sourceTypes: ["BlockSettings"],
+        heading: "Block Settings",
+        description: "Embedded as settings in a Block List / Block Grid property."
+    },
+    {
+        sourceTypes: ["ElementPicker"],
+        heading: "Element Picker",
+        description: "Referenced by an Element Picker property (Umbraco 18+)."
+    },
+    {
+        sourceTypes: ["LibraryItem", "LibraryItem (Trashed)"],
+        heading: "Library Items",
+        description: "Standing Library items of this Element Type (Umbraco 18+)."
+    }
+];
+
+@customElement("godmode-element-type-usage-modal")
+export class GodModeElementTypeUsageModalElement extends UmbElementMixin(LitElement) {
+    @property({ attribute: false }) modalContext?: { reject: () => void };
+    @property({ type: Object, attribute: false }) data?: GodModeElementTypeUsageModalData;
+    @state() private _items: ElementTypeUsageDetail[] = [];
+    @state() private _loading = true;
+    @state() private _search = "";
+    @state() private _error = "";
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        window.addEventListener("pointerdown", this._onOutsidePointerDown, { capture: true });
+        void this._load();
+    }
+
+    override disconnectedCallback(): void {
+        window.removeEventListener("pointerdown", this._onOutsidePointerDown, { capture: true });
+        super.disconnectedCallback();
+    }
+
+    private async _load() {
+        if (!this.data?.elementTypeKey) {
+            this._loading = false;
+            return;
+        }
+
+        this._loading = true;
+        this._error = "";
+        try {
+            this._items = await godmodeGet<ElementTypeUsageDetail[]>("element-type-usage/detail", {
+                elementTypeKey: this.data.elementTypeKey
+            });
+        } catch (error) {
+            this._error = error instanceof Error ? error.message : "Unable to load Element Type usage.";
+        } finally {
+            this._loading = false;
+        }
+    }
+
+    private _filtered(): ElementTypeUsageDetail[] {
+        const q = this._search.trim().toLowerCase();
+        if (!q) return this._items;
+        return this._items.filter((item) =>
+            [item.contentName, item.parentName ?? "", item.contentPath, item.sourceType].some((value) => value.toLowerCase().includes(q))
+        );
+    }
+
+    private _close = () => {
+        this.modalContext?.reject();
+    };
+
+    private _onOutsidePointerDown = (e: PointerEvent) => {
+        if (e.composedPath().includes(this)) {
+            return;
+        }
+
+        this._close();
+    };
+
+    private _usageEditUrl(entityType: ElementTypeUsageEntityType, key: string): string {
+        switch (entityType) {
+            case "content":
+                return editUrl("content", key);
+            case "media":
+                return editUrl("media", key);
+            case "member":
+                return editUrl("member", key);
+            case "element":
+                // Umbraco 18+ Library item. GodMode's client package targets Umbraco 17
+                // (@umbraco-cms/backoffice ^17.3.0), which has no typed path pattern for the
+                // Library section yet, so the route is built manually here rather than via
+                // the shared edit-links helpers. This matches the route Umbraco 18's `elements`
+                // package registers: section/library/workspace/element/edit/{key}.
+                return `section/library/workspace/element/edit/${key}`;
+            default:
+                return "";
+        }
+    }
+
+    override render() {
+        const target = this.data?.elementTypeName || this.data?.elementTypeAlias || this.data?.elementTypeKey || "Selected Element Type";
+        const results = this._filtered();
+
+        return html`
+            <godmode-modal-layout headline=${`Element Type Usage: ${target}`} @close=${this._close}>
+                <div class="summary">
+                    ${this.data?.elementTypeAlias ? html`<code>${this.data.elementTypeAlias}</code>` : ""}
+                    ${this.data?.elementTypeKey ? html`<small><code>${this.data.elementTypeKey}</code></small>` : ""}
+                </div>
+
+                <uui-box>
+                    <label>Search</label>
+                    <uui-input
+                        type="search"
+                        autocomplete="off"
+                        autocorrect="off"
+                        autocapitalize="off"
+                        spellcheck="false"
+                        placeholder="Filter by name, parent, path or source"
+                        .value=${this._search}
+                        @input=${(e: Event) => (this._search = (e.target as HTMLInputElement).value)}
+                    ></uui-input>
+                </uui-box>
+
+                ${this._loading
+                    ? html`<uui-loader></uui-loader>`
+                    : this._error
+                      ? html`<uui-box><p class="empty">${this._error}</p></uui-box>`
+                      : html`
+                            <p class="results"><strong>${results.length}</strong> / <strong>${this._items.length}</strong> usages</p>
+                            ${results.length ? SOURCE_GROUPS.map((group) => this._renderGroup(group, results)) : html`<uui-box><p>No usages found. This Element Type is unused.</p></uui-box>`}
+                        `}
+            </godmode-modal-layout>
+        `;
+    }
+
+    private _renderGroup(group: (typeof SOURCE_GROUPS)[number], results: ElementTypeUsageDetail[]) {
+        const rows = results.filter((item) => group.sourceTypes.includes(item.sourceType));
+        if (!rows.length) return "";
+
+        return html`
+            <uui-box headline=${`${group.heading} (${rows.length})`}>
+                <p class="section-description">${group.description}</p>
+                <uui-table>
+                    <uui-table-head>
+                        <uui-table-head-cell>Content Name</uui-table-head-cell>
+                        <uui-table-head-cell>Parent Name</uui-table-head-cell>
+                        <uui-table-head-cell>Version Date</uui-table-head-cell>
+                        <uui-table-head-cell>Source Type</uui-table-head-cell>
+                    </uui-table-head>
+                    ${rows.map((row) => {
+                        const link = this._usageEditUrl(row.entityType, row.contentKey);
+                        return html`
+                            <uui-table-row>
+                                <uui-table-cell>
+                                    ${link
+                                        ? html`<a href=${link} target="_blank" rel="noopener noreferrer"><strong>${row.contentName}</strong></a>`
+                                        : html`<strong>${row.contentName}</strong>`}
+                                </uui-table-cell>
+                                <uui-table-cell>${row.parentName ?? html`<span class="muted">None</span>`}</uui-table-cell>
+                                <uui-table-cell><small>${truncate(row.versionDate, 22)}</small></uui-table-cell>
+                                <uui-table-cell><span class="pill">${row.sourceType}</span></uui-table-cell>
+                            </uui-table-row>
+                        `;
+                    })}
+                </uui-table>
+            </uui-box>
+        `;
+    }
+
+    static override styles = css`
+        .summary {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: var(--uui-size-space-2);
+            margin-bottom: var(--uui-size-space-4);
+        }
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: var(--uui-size-space-1);
+        }
+        uui-input {
+            width: 100%;
+        }
+        .results {
+            margin: var(--uui-size-space-3) 0;
+            color: var(--uui-color-text-alt);
+        }
+        .section-description {
+            color: var(--uui-color-text-alt);
+            margin-top: 0;
+        }
+        uui-box + uui-box {
+            margin-top: var(--uui-size-space-4);
+        }
+        .muted {
+            color: var(--uui-color-text-alt);
+        }
+        .empty {
+            color: var(--uui-color-text-alt);
+        }
+        .pill {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: var(--uui-border-radius);
+            background: var(--uui-color-surface-alt);
+            font-size: 12px;
+        }
+        a {
+            color: var(--uui-color-interactive);
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    `;
+}
+
+export default GodModeElementTypeUsageModalElement;
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "godmode-element-type-usage-modal": GodModeElementTypeUsageModalElement;
+    }
+}

--- a/Diplo.GodMode/Client/src/elements/godmode-element-type-usage-modal.element.ts
+++ b/Diplo.GodMode/Client/src/elements/godmode-element-type-usage-modal.element.ts
@@ -19,14 +19,19 @@ const SOURCE_GROUPS: Array<{ sourceTypes: ElementTypeUsageSourceType[]; heading:
         description: "Embedded as settings in a Block List / Block Grid property."
     },
     {
+        sourceTypes: ["ConfigurationContent", "ConfigurationSettings"],
+        heading: "Data Type Configuration",
+        description: "Configured as an available content or settings type in a block editor data type."
+    },
+    {
         sourceTypes: ["ElementPicker"],
         heading: "Element Picker",
-        description: "Referenced by an Element Picker property (Umbraco 18+)."
+        description: "Referenced by an Element Picker property when the Umbraco Elements feature is available."
     },
     {
         sourceTypes: ["LibraryItem", "LibraryItem (Trashed)"],
         heading: "Library Items",
-        description: "Standing Library items of this Element Type (Umbraco 18+)."
+        description: "Standing Library items of this Element Type when the Umbraco Elements feature is available."
     }
 ];
 
@@ -97,12 +102,11 @@ export class GodModeElementTypeUsageModalElement extends UmbElementMixin(LitElem
                 return editUrl("media", key);
             case "member":
                 return editUrl("member", key);
+            case "dataType":
+                return editUrl("dataType", key);
             case "element":
-                // Umbraco 18+ Library item. GodMode's client package targets Umbraco 17
-                // (@umbraco-cms/backoffice ^17.3.0), which has no typed path pattern for the
-                // Library section yet, so the route is built manually here rather than via
-                // the shared edit-links helpers. This matches the route Umbraco 18's `elements`
-                // package registers: section/library/workspace/element/edit/{key}.
+                // The client targets Umbraco 17, which does not expose a typed Library route helper.
+                // This is only used for rows returned after the server detects the v18 schema.
                 return `section/library/workspace/element/edit/${key}`;
             default:
                 return "";
@@ -155,8 +159,8 @@ export class GodModeElementTypeUsageModalElement extends UmbElementMixin(LitElem
                 <p class="section-description">${group.description}</p>
                 <uui-table>
                     <uui-table-head>
-                        <uui-table-head-cell>Content Name</uui-table-head-cell>
-                        <uui-table-head-cell>Parent Name</uui-table-head-cell>
+                        <uui-table-head-cell>Owner</uui-table-head-cell>
+                        <uui-table-head-cell>Parent / Editor</uui-table-head-cell>
                         <uui-table-head-cell>Version Date</uui-table-head-cell>
                         <uui-table-head-cell>Source Type</uui-table-head-cell>
                     </uui-table-head>

--- a/Diplo.GodMode/Client/src/manifests/catalog.ts
+++ b/Diplo.GodMode/Client/src/manifests/catalog.ts
@@ -2,6 +2,7 @@ import { browserManifests, type BrowserDef } from "./browsers";
 import { menuManifests } from "./menu";
 import type { ManifestBase } from "@umbraco-cms/backoffice/extension-api";
 import { GODMODE_USED_BY_MODAL_ALIAS } from "../shared/used-by-modal";
+import { GODMODE_ELEMENT_TYPE_USAGE_MODAL_ALIAS } from "../shared/element-type-usage-modal";
 import { GODMODE_EVIDENCE_DRAWER_ALIAS } from "../shared/evidence-drawer";
 import { treeManifests } from "../tree/manifests";
 import { collectionManifests } from "../collection/manifests";
@@ -96,6 +97,14 @@ export const browsers: BrowserDef[] = [
         description: "See how your content types are used and how many instances have been made",
         weight: 790,
         element: () => import("../elements/godmode-usage-browser.element")
+    },
+    {
+        id: "elementTypeUsage",
+        label: "Element Type Usage",
+        icon: "icon-science",
+        description: "Browse Element Type usage across Block Lists, Block Grids, Library Items and Element Pickers",
+        weight: 780,
+        element: () => import("../elements/godmode-element-type-usage-browser.element")
     },
     {
         id: "databaseBrowser",
@@ -376,6 +385,12 @@ export const allManifests: ManifestBase[] = [
         alias: GODMODE_EVIDENCE_DRAWER_ALIAS,
         name: "GodMode Evidence Drawer",
         element: () => import("../elements/godmode-evidence-drawer.element")
+    } as ManifestBase,
+    {
+        type: "modal",
+        alias: GODMODE_ELEMENT_TYPE_USAGE_MODAL_ALIAS,
+        name: "GodMode Element Type Usage Modal",
+        element: () => import("../elements/godmode-element-type-usage-modal.element")
     } as ManifestBase,
     ...browsers.flatMap(browserManifests)
 ];

--- a/Diplo.GodMode/Client/src/manifests/catalog.ts
+++ b/Diplo.GodMode/Client/src/manifests/catalog.ts
@@ -102,7 +102,7 @@ export const browsers: BrowserDef[] = [
         id: "elementTypeUsage",
         label: "Element Type Usage",
         icon: "icon-science",
-        description: "Browse Element Type usage across Block Lists, Block Grids, Library Items and Element Pickers",
+        description: "Browse stored and configured Element Type usage, including Library usage when available",
         weight: 780,
         element: () => import("../elements/godmode-element-type-usage-browser.element")
     },

--- a/Diplo.GodMode/Client/src/shared/element-type-usage-modal.ts
+++ b/Diplo.GodMode/Client/src/shared/element-type-usage-modal.ts
@@ -1,0 +1,17 @@
+import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
+import { umbOpenModal } from "@umbraco-cms/backoffice/modal";
+import { openWithModalFeedback } from "./modal-feedback";
+
+export const GODMODE_ELEMENT_TYPE_USAGE_MODAL_ALIAS = "Diplo.Modal.GodMode.ElementTypeUsage";
+
+export interface GodModeElementTypeUsageModalData {
+    elementTypeKey: string;
+    elementTypeName?: string;
+    elementTypeAlias?: string;
+}
+
+export function openElementTypeUsageModal(host: UmbControllerHost, data: GodModeElementTypeUsageModalData, e?: Event): void {
+    void openWithModalFeedback(e, () => {
+        void umbOpenModal(host, GODMODE_ELEMENT_TYPE_USAGE_MODAL_ALIAS, { data }).catch(() => undefined);
+    });
+}

--- a/Diplo.GodMode/Client/src/shared/index.ts
+++ b/Diplo.GodMode/Client/src/shared/index.ts
@@ -8,6 +8,7 @@ export * from "./ai-availability";
 export * from "./sort";
 export * from "./reference-links";
 export * from "./used-by-modal";
+export * from "./element-type-usage-modal";
 export * from "./evidence-drawer";
 export * from "./modal-feedback";
 export * from "./format";

--- a/Diplo.GodMode/Client/src/shared/types.ts
+++ b/Diplo.GodMode/Client/src/shared/types.ts
@@ -725,7 +725,7 @@ export interface GodModeConfigResponse {
     };
 }
 
-/** One row in the Element Type Usage grid — aggregated counts across all four usage sources. */
+/** One row in the Element Type Usage grid — stored, configured and optional Library usage. */
 export interface ElementTypeUsageSummary {
     elementTypeId: number;
     elementTypeKey: string;
@@ -734,6 +734,7 @@ export interface ElementTypeUsageSummary {
     icon: string | null;
     contentUses: number;
     settingsUses: number;
+    configuredUses: number;
     libraryItems: number;
     elementPickerUses: number;
     usageCount: number;
@@ -743,12 +744,14 @@ export interface ElementTypeUsageSummary {
 export type ElementTypeUsageSourceType =
     | "BlockContent"
     | "BlockSettings"
+    | "ConfigurationContent"
+    | "ConfigurationSettings"
     | "ElementPicker"
     | "LibraryItem"
     | "LibraryItem (Trashed)";
 
 /** Entity type of the node that owns a usage — used to build the correct edit link. */
-export type ElementTypeUsageEntityType = "content" | "media" | "member" | "element" | "unknown";
+export type ElementTypeUsageEntityType = "content" | "media" | "member" | "dataType" | "element" | "unknown";
 
 export interface ElementTypeUsageDetail {
     contentNodeId: number;
@@ -762,8 +765,7 @@ export interface ElementTypeUsageDetail {
 }
 
 /**
- * Reports whether Element Type Usage analysis can run on the current database, and whether
- * Library Item / Element Picker reporting (Umbraco 18+) is available.
+ * Reports whether Element Type Usage analysis can run and whether optional Library reporting is available.
  */
 export interface ElementTypeUsageStatus {
     isSupported: boolean;

--- a/Diplo.GodMode/Client/src/shared/types.ts
+++ b/Diplo.GodMode/Client/src/shared/types.ts
@@ -725,3 +725,49 @@ export interface GodModeConfigResponse {
     };
 }
 
+/** One row in the Element Type Usage grid — aggregated counts across all four usage sources. */
+export interface ElementTypeUsageSummary {
+    elementTypeId: number;
+    elementTypeKey: string;
+    elementTypeName: string;
+    elementTypeAlias: string;
+    icon: string | null;
+    contentUses: number;
+    settingsUses: number;
+    libraryItems: number;
+    elementPickerUses: number;
+    usageCount: number;
+}
+
+/** One usage occurrence for a single Element Type, shown in the Element Type Usage detail modal. */
+export type ElementTypeUsageSourceType =
+    | "BlockContent"
+    | "BlockSettings"
+    | "ElementPicker"
+    | "LibraryItem"
+    | "LibraryItem (Trashed)";
+
+/** Entity type of the node that owns a usage — used to build the correct edit link. */
+export type ElementTypeUsageEntityType = "content" | "media" | "member" | "element" | "unknown";
+
+export interface ElementTypeUsageDetail {
+    contentNodeId: number;
+    contentKey: string;
+    contentName: string;
+    parentName: string | null;
+    contentPath: string;
+    versionDate: string;
+    sourceType: ElementTypeUsageSourceType;
+    entityType: ElementTypeUsageEntityType;
+}
+
+/**
+ * Reports whether Element Type Usage analysis can run on the current database, and whether
+ * Library Item / Element Picker reporting (Umbraco 18+) is available.
+ */
+export interface ElementTypeUsageStatus {
+    isSupported: boolean;
+    libraryFeatureAvailable: boolean;
+    message: string | null;
+}
+

--- a/Diplo.GodMode/Client/src/tree/structure.ts
+++ b/Diplo.GodMode/Client/src/tree/structure.ts
@@ -57,7 +57,7 @@ const GROUPS: GroupDef[] = [
             "tagBrowser"
         ]
     },
-    { unique: "group-relationships", name: "Relationships & usage", ids: ["referenceGraph", "usageBrowser"] },
+    { unique: "group-relationships", name: "Relationships & usage", ids: ["referenceGraph", "usageBrowser", "elementTypeUsage"] },
     {
         unique: "group-developer",
         name: "Developer & runtime",

--- a/Diplo.GodMode/Controllers/GodModeApiController.cs
+++ b/Diplo.GodMode/Controllers/GodModeApiController.cs
@@ -578,6 +578,23 @@ public class GodModeApiController : ManagementApiControllerBase
     public ActionResult<IEnumerable<UsageModel>> GetContentUsageData(int? id = null, string? orderBy = null)
         => Ok(dataBaseService.GetContentUsageData(id, orderBy));
 
+    // ─── Element Type usage ──────────────────────────────────────────
+
+    [HttpGet("element-type-usage/status")]
+    [ProducesResponseType<ElementTypeUsageStatus>(StatusCodes.Status200OK)]
+    public ActionResult<ElementTypeUsageStatus> GetElementTypeUsageStatus()
+        => Ok(dataBaseService.GetElementTypeUsageStatus());
+
+    [HttpGet("element-type-usage")]
+    [ProducesResponseType<IEnumerable<ElementTypeUsageSummary>>(StatusCodes.Status200OK)]
+    public ActionResult<IEnumerable<ElementTypeUsageSummary>> GetElementTypeUsageSummary()
+        => Ok(dataBaseService.GetElementTypeUsageSummary());
+
+    [HttpGet("element-type-usage/detail")]
+    [ProducesResponseType<IEnumerable<ElementTypeUsageDetail>>(StatusCodes.Status200OK)]
+    public ActionResult<IEnumerable<ElementTypeUsageDetail>> GetElementTypeUsageDetail([FromQuery] Guid elementTypeKey)
+        => Ok(dataBaseService.GetElementTypeUsageDetail(elementTypeKey));
+
     [HttpGet("tags")]
     [ProducesResponseType<IEnumerable<TagMapping>>(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<TagMapping>>> GetTagMapping()

--- a/Diplo.GodMode/Controllers/GodModeApiController.cs
+++ b/Diplo.GodMode/Controllers/GodModeApiController.cs
@@ -587,13 +587,13 @@ public class GodModeApiController : ManagementApiControllerBase
 
     [HttpGet("element-type-usage")]
     [ProducesResponseType<IEnumerable<ElementTypeUsageSummary>>(StatusCodes.Status200OK)]
-    public ActionResult<IEnumerable<ElementTypeUsageSummary>> GetElementTypeUsageSummary()
-        => Ok(dataBaseService.GetElementTypeUsageSummary());
+    public async Task<ActionResult<IEnumerable<ElementTypeUsageSummary>>> GetElementTypeUsageSummary([FromQuery] bool refresh = false)
+        => Ok(await dataBaseService.GetElementTypeUsageSummary(refresh));
 
     [HttpGet("element-type-usage/detail")]
     [ProducesResponseType<IEnumerable<ElementTypeUsageDetail>>(StatusCodes.Status200OK)]
-    public ActionResult<IEnumerable<ElementTypeUsageDetail>> GetElementTypeUsageDetail([FromQuery] Guid elementTypeKey)
-        => Ok(dataBaseService.GetElementTypeUsageDetail(elementTypeKey));
+    public async Task<ActionResult<IEnumerable<ElementTypeUsageDetail>>> GetElementTypeUsageDetail([FromQuery] Guid elementTypeKey)
+        => Ok(await dataBaseService.GetElementTypeUsageDetail(elementTypeKey));
 
     [HttpGet("tags")]
     [ProducesResponseType<IEnumerable<TagMapping>>(StatusCodes.Status200OK)]

--- a/Diplo.GodMode/Models/ElementTypeUsageModels.cs
+++ b/Diplo.GodMode/Models/ElementTypeUsageModels.cs
@@ -3,9 +3,9 @@ using System;
 namespace Diplo.GodMode.Models;
 
 /// <summary>
-/// Aggregated Element Type usage counts for the main Element Type Usage grid. Returned for every
-/// Element Type in the installation, including those with zero usages (so unused types can be
-/// identified and filtered).
+/// Aggregated Element Type usage counts for the main Element Type Usage grid. Stored block
+/// occurrences and block-editor configuration references are both included so a zero count is a
+/// meaningful unused signal.
 /// </summary>
 public class ElementTypeUsageSummary
 {
@@ -30,19 +30,25 @@ public class ElementTypeUsageSummary
     public int SettingsUses { get; set; }
 
     /// <summary>
-    /// Standing Library items of this Element Type. Umbraco 18+ only; always 0 below Umbraco 18.
+    /// Block editor data-type configurations that reference this Element Type as content or settings.
+    /// </summary>
+    public int ConfiguredUses { get; set; }
+
+    /// <summary>
+    /// Standing Library items of this Element Type. Available when the Umbraco 18 Elements schema
+    /// is present; otherwise zero.
     /// </summary>
     public int LibraryItems { get; set; }
 
     /// <summary>
-    /// Element Picker references to Library items of this Element Type. Umbraco 18+ only; always 0
-    /// below Umbraco 18.
+    /// Element Picker references to Library items of this Element Type. Available when the Umbraco
+    /// 18 Elements schema is present; otherwise zero.
     /// </summary>
     public int ElementPickerUses { get; set; }
 
     /// <summary>
-    /// Total usage count across all sources. An Element Type is genuinely unused only when this is
-    /// zero across BlockContent, BlockSettings, ElementPicker and LibraryItem sources.
+    /// Total usage count across stored blocks, block-editor configuration references, Library
+    /// items and Element Picker references.
     /// </summary>
     public int UsageCount { get; set; }
 }
@@ -52,6 +58,8 @@ public class ElementTypeUsageSummary
 /// </summary>
 public class ElementTypeUsageDetail
 {
+    internal Guid ElementTypeKey { get; set; }
+
     public int ContentNodeId { get; set; }
 
     public Guid ContentKey { get; set; }
@@ -65,41 +73,39 @@ public class ElementTypeUsageDetail
     public DateTime VersionDate { get; set; }
 
     /// <summary>
-    /// One of: BlockContent, BlockSettings, ElementPicker, LibraryItem, LibraryItem (Trashed).
+    /// One of: BlockContent, BlockSettings, ConfigurationContent, ConfigurationSettings,
+    /// ElementPicker, LibraryItem, LibraryItem (Trashed).
     /// </summary>
     public string SourceType { get; set; } = string.Empty;
 
     /// <summary>
-    /// The entity type of the node that owns this usage — content, media, member, element, or
-    /// unknown — used by the client to build the correct edit link.
+    /// The entity type of the node that owns this usage — content, media, member, dataType, element,
+    /// or unknown — used by the client to build the correct edit link.
     /// </summary>
     public string EntityType { get; set; } = "unknown";
 }
 
+internal sealed record ElementTypeConfigurationReference(Guid ElementTypeKey, string SourceType);
+
 /// <summary>
-/// Reports whether Element Type Usage analysis can run on the current database, and which of the
-/// four usage sources are available.
+/// Reports whether Element Type Usage analysis can run on the current database.
 /// </summary>
 public class ElementTypeUsageStatus
 {
     /// <summary>
-    /// False when the analysis query cannot run at all (SQLite, or SQL Server below compatibility
-    /// level 130 — both BlockContent and BlockSettings sources rely on OPENJSON). When false, no
-    /// usage query is executed and <see cref="Message"/> explains why.
+    /// False when the analysis query cannot run. SQL Server requires compatibility level 130 or
+    /// higher for OPENJSON; SQLite uses its bundled JSON1 support.
     /// </summary>
     public bool IsSupported { get; set; }
 
     /// <summary>
-    /// True when the <c>umbracoElement</c> table exists (Umbraco 18+), enabling Library Item and
-    /// Element Picker reporting alongside BlockContent/BlockSettings. When false, only the block
-    /// editor sources are reported.
+    /// True when the Umbraco Elements schema is present, enabling Library Item and Element Picker
+    /// reporting. False on Umbraco 17.
     /// </summary>
     public bool LibraryFeatureAvailable { get; set; }
 
     /// <summary>
-    /// Explanatory message shown to the user when <see cref="IsSupported"/> is false, or an
-    /// informational note when <see cref="LibraryFeatureAvailable"/> is false. Null when everything
-    /// is fully supported.
+    /// Explanatory message shown to the user when <see cref="IsSupported"/> is false.
     /// </summary>
     public string? Message { get; set; }
 }

--- a/Diplo.GodMode/Models/ElementTypeUsageModels.cs
+++ b/Diplo.GodMode/Models/ElementTypeUsageModels.cs
@@ -1,0 +1,105 @@
+using System;
+
+namespace Diplo.GodMode.Models;
+
+/// <summary>
+/// Aggregated Element Type usage counts for the main Element Type Usage grid. Returned for every
+/// Element Type in the installation, including those with zero usages (so unused types can be
+/// identified and filtered).
+/// </summary>
+public class ElementTypeUsageSummary
+{
+    public int ElementTypeId { get; set; }
+
+    public Guid ElementTypeKey { get; set; }
+
+    public string ElementTypeName { get; set; } = string.Empty;
+
+    public string ElementTypeAlias { get; set; } = string.Empty;
+
+    public string? Icon { get; set; }
+
+    /// <summary>
+    /// Usages found in Block List / Block Grid <c>contentData</c>.
+    /// </summary>
+    public int ContentUses { get; set; }
+
+    /// <summary>
+    /// Usages found in Block List / Block Grid <c>settingsData</c>.
+    /// </summary>
+    public int SettingsUses { get; set; }
+
+    /// <summary>
+    /// Standing Library items of this Element Type. Umbraco 18+ only; always 0 below Umbraco 18.
+    /// </summary>
+    public int LibraryItems { get; set; }
+
+    /// <summary>
+    /// Element Picker references to Library items of this Element Type. Umbraco 18+ only; always 0
+    /// below Umbraco 18.
+    /// </summary>
+    public int ElementPickerUses { get; set; }
+
+    /// <summary>
+    /// Total usage count across all sources. An Element Type is genuinely unused only when this is
+    /// zero across BlockContent, BlockSettings, ElementPicker and LibraryItem sources.
+    /// </summary>
+    public int UsageCount { get; set; }
+}
+
+/// <summary>
+/// A single usage occurrence for an Element Type, shown in the workspace detail view.
+/// </summary>
+public class ElementTypeUsageDetail
+{
+    public int ContentNodeId { get; set; }
+
+    public Guid ContentKey { get; set; }
+
+    public string ContentName { get; set; } = string.Empty;
+
+    public string? ParentName { get; set; }
+
+    public string ContentPath { get; set; } = string.Empty;
+
+    public DateTime VersionDate { get; set; }
+
+    /// <summary>
+    /// One of: BlockContent, BlockSettings, ElementPicker, LibraryItem, LibraryItem (Trashed).
+    /// </summary>
+    public string SourceType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The entity type of the node that owns this usage — content, media, member, element, or
+    /// unknown — used by the client to build the correct edit link.
+    /// </summary>
+    public string EntityType { get; set; } = "unknown";
+}
+
+/// <summary>
+/// Reports whether Element Type Usage analysis can run on the current database, and which of the
+/// four usage sources are available.
+/// </summary>
+public class ElementTypeUsageStatus
+{
+    /// <summary>
+    /// False when the analysis query cannot run at all (SQLite, or SQL Server below compatibility
+    /// level 130 — both BlockContent and BlockSettings sources rely on OPENJSON). When false, no
+    /// usage query is executed and <see cref="Message"/> explains why.
+    /// </summary>
+    public bool IsSupported { get; set; }
+
+    /// <summary>
+    /// True when the <c>umbracoElement</c> table exists (Umbraco 18+), enabling Library Item and
+    /// Element Picker reporting alongside BlockContent/BlockSettings. When false, only the block
+    /// editor sources are reported.
+    /// </summary>
+    public bool LibraryFeatureAvailable { get; set; }
+
+    /// <summary>
+    /// Explanatory message shown to the user when <see cref="IsSupported"/> is false, or an
+    /// informational note when <see cref="LibraryFeatureAvailable"/> is false. Null when everything
+    /// is fully supported.
+    /// </summary>
+    public string? Message { get; set; }
+}

--- a/Diplo.GodMode/Services/Interfaces/IUmbracoDatabaseService.cs
+++ b/Diplo.GodMode/Services/Interfaces/IUmbracoDatabaseService.cs
@@ -2,6 +2,7 @@
 using NPoco;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Diplo.GodMode.Services.Interfaces
 {
@@ -19,22 +20,21 @@ namespace Diplo.GodMode.Services.Interfaces
         DatabaseType GetDatabaseType();
 
         /// <summary>
-        /// Reports whether Element Type Usage analysis can run on the current database (SQL Server
-        /// with compatibility level 130+ for OPENJSON), and whether Library Item / Element Picker
-        /// reporting is available (requires the Umbraco 18+ <c>umbracoElement</c> table).
+        /// Reports whether Element Type Usage analysis can run on the current database and whether
+        /// the optional Umbraco Elements schema is available.
         /// </summary>
         ElementTypeUsageStatus GetElementTypeUsageStatus();
 
         /// <summary>
-        /// Gets aggregated usage counts for every Element Type (BlockContent, BlockSettings, Library
-        /// Items and Element Picker references), including Element Types with zero usages.
+        /// Gets aggregated stored, configured, Library Item and Element Picker usage counts for
+        /// every Element Type, including Element Types with zero usages.
         /// </summary>
-        IEnumerable<ElementTypeUsageSummary> GetElementTypeUsageSummary();
+        Task<IEnumerable<ElementTypeUsageSummary>> GetElementTypeUsageSummary(bool refresh = false);
 
         /// <summary>
         /// Gets every individual usage occurrence for a single Element Type, across all sources.
         /// </summary>
-        IEnumerable<ElementTypeUsageDetail> GetElementTypeUsageDetail(Guid elementTypeKey);
+        Task<IEnumerable<ElementTypeUsageDetail>> GetElementTypeUsageDetail(Guid elementTypeKey);
 
         IEnumerable<Lang> GetLanguages();
 

--- a/Diplo.GodMode/Services/Interfaces/IUmbracoDatabaseService.cs
+++ b/Diplo.GodMode/Services/Interfaces/IUmbracoDatabaseService.cs
@@ -1,5 +1,6 @@
 ﻿using Diplo.GodMode.Models;
 using NPoco;
+using System;
 using System.Collections.Generic;
 
 namespace Diplo.GodMode.Services.Interfaces
@@ -16,6 +17,24 @@ namespace Diplo.GodMode.Services.Interfaces
         List<UsageModel> GetContentUsageData(int? id = null, string orderBy = "CT.alias");
 
         DatabaseType GetDatabaseType();
+
+        /// <summary>
+        /// Reports whether Element Type Usage analysis can run on the current database (SQL Server
+        /// with compatibility level 130+ for OPENJSON), and whether Library Item / Element Picker
+        /// reporting is available (requires the Umbraco 18+ <c>umbracoElement</c> table).
+        /// </summary>
+        ElementTypeUsageStatus GetElementTypeUsageStatus();
+
+        /// <summary>
+        /// Gets aggregated usage counts for every Element Type (BlockContent, BlockSettings, Library
+        /// Items and Element Picker references), including Element Types with zero usages.
+        /// </summary>
+        IEnumerable<ElementTypeUsageSummary> GetElementTypeUsageSummary();
+
+        /// <summary>
+        /// Gets every individual usage occurrence for a single Element Type, across all sources.
+        /// </summary>
+        IEnumerable<ElementTypeUsageDetail> GetElementTypeUsageDetail(Guid elementTypeKey);
 
         IEnumerable<Lang> GetLanguages();
 

--- a/Diplo.GodMode/Services/UmbracoDatabaseService.cs
+++ b/Diplo.GodMode/Services/UmbracoDatabaseService.cs
@@ -17,6 +17,30 @@ namespace Diplo.GodMode.Services
     public class UmbracoDatabaseService : IUmbracoDatabaseService
     {
         private const string DatabaseTablesCacheKey = "Diplo.GodMode.DatabaseTables";
+
+        /// <summary>
+        /// Cache key for the aggregated Element Type usage summary. This query scans every Block
+        /// List/Grid property and (on Umbraco 18+) every Library item and Element Picker relation,
+        /// so it's cached briefly - this is a single-developer diagnostic tool, not a live report,
+        /// and usage patterns don't meaningfully change within a few minutes of browsing the grid.
+        /// </summary>
+        private const string ElementTypeUsageSummaryCacheKey = "Diplo.GodMode.ElementTypeUsageSummary";
+
+        private static readonly TimeSpan ElementTypeUsageSummaryCacheDuration = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// The Umbraco 18+ table backing Library items. Its presence is used to detect whether the
+        /// Library feature (and therefore LibraryItem / ElementPicker usage reporting) is available.
+        /// </summary>
+        private const string UmbracoElementTableName = "umbracoElement";
+
+        /// <summary>
+        /// Mirrors Umbraco.Cms.Core.Constants.ObjectTypes.Strings.Element in Umbraco 18+. GodMode's
+        /// server assembly targets Umbraco.Cms.Core [17.0.0,18.0.0), where the Element object type
+        /// does not exist, so this is hardcoded rather than referenced from Umbraco.Cms.Core.
+        /// </summary>
+        private const string ElementObjectTypeString = "3D7B623C-94B1-487D-8554-A46EC37568BE";
+
         private readonly IScopeProvider scopeProvider;
         private readonly ILogger<UmbracoDatabaseService> logger;
         private readonly IPublishedContentQuery contentQuery;
@@ -422,6 +446,311 @@ namespace Diplo.GodMode.Services
             {
                 return scope.Database.Fetch<UsageModel>(query);
             }
+        }
+
+        /// <summary>
+        /// Reports whether Element Type Usage analysis can run on the current database, and whether
+        /// Library Item / Element Picker reporting is available. Supported on both SQL Server (via
+        /// OPENJSON) and SQLite (via the JSON1 extension's json_each/json_extract, bundled with the
+        /// SQLite provider Umbraco ships) so the analysis also works against a database pulled down
+        /// from Umbraco Cloud for local development.
+        /// </summary>
+        public ElementTypeUsageStatus GetElementTypeUsageStatus()
+        {
+            using var scope = this.scopeProvider.CreateScope(autoComplete: true);
+
+            if (this.scopeProvider.SqlContext.DatabaseType != DatabaseType.SQLite)
+            {
+                var compatibilityLevel = scope.Database.ExecuteScalar<int?>(
+                    "SELECT compatibility_level FROM sys.databases WHERE name = DB_NAME()");
+
+                if (compatibilityLevel is null or < 130)
+                {
+                    return new ElementTypeUsageStatus
+                    {
+                        IsSupported = false,
+                        LibraryFeatureAvailable = false,
+                        Message = "Element Type Usage requires SQL compatibility level 130 or higher. OPENJSON is unavailable below compatibility level 130."
+                    };
+                }
+            }
+
+            bool libraryFeatureAvailable = GetTableNames(scope.Database)
+                .Any(table => table.Name.InvariantEquals(UmbracoElementTableName));
+
+            return new ElementTypeUsageStatus
+            {
+                IsSupported = true,
+                LibraryFeatureAvailable = libraryFeatureAvailable,
+                Message = libraryFeatureAvailable
+                    ? null
+                    : "Library Items and Element Picker usage require Umbraco 18+ (the umbracoElement table was not found). Only Block List / Block Grid usage is reported."
+            };
+        }
+
+        /// <summary>
+        /// Gets aggregated Element Type usage counts for the Element Type Usage grid, including
+        /// Element Types with zero usages so unused types can be identified. Cached briefly (see
+        /// <see cref="ElementTypeUsageSummaryCacheDuration"/>) since this is a single-developer
+        /// diagnostic tool where usage doesn't meaningfully change minute to minute; use the grid's
+        /// reload button to force a fresh read once the cache entry expires.
+        /// </summary>
+        public IEnumerable<ElementTypeUsageSummary> GetElementTypeUsageSummary()
+        {
+            if (this.memoryCache.TryGetValue(ElementTypeUsageSummaryCacheKey, out IReadOnlyList<ElementTypeUsageSummary>? cached) && cached is not null)
+            {
+                return cached;
+            }
+
+            ElementTypeUsageStatus status = GetElementTypeUsageStatus();
+            if (!status.IsSupported)
+            {
+                return [];
+            }
+
+            using var scope = this.scopeProvider.CreateScope(autoComplete: true);
+
+            var sql = new Sql(BuildElementTypeUsageCte(status.LibraryFeatureAvailable, this.scopeProvider.SqlContext.DatabaseType) + @"
+SELECT
+    ET.nodeId AS ElementTypeId,
+    ETN.uniqueId AS ElementTypeKey,
+    ETN.[text] AS ElementTypeName,
+    ET.alias AS ElementTypeAlias,
+    ET.icon AS Icon,
+    COALESCE(U.ContentUses, 0) AS ContentUses,
+    COALESCE(U.SettingsUses, 0) AS SettingsUses,
+    COALESCE(U.LibraryItems, 0) AS LibraryItems,
+    COALESCE(U.ElementPickerUses, 0) AS ElementPickerUses,
+    COALESCE(U.UsageCount, 0) AS UsageCount
+FROM cmsContentType ET
+INNER JOIN umbracoNode ETN ON ETN.id = ET.nodeId
+LEFT JOIN
+(
+    SELECT
+        ElementTypeId,
+        SUM(CASE WHEN SourceType = 'BlockContent' THEN 1 ELSE 0 END) AS ContentUses,
+        SUM(CASE WHEN SourceType = 'BlockSettings' THEN 1 ELSE 0 END) AS SettingsUses,
+        SUM(CASE WHEN SourceType IN ('LibraryItem', 'LibraryItem (Trashed)') THEN 1 ELSE 0 END) AS LibraryItems,
+        SUM(CASE WHEN SourceType = 'ElementPicker' THEN 1 ELSE 0 END) AS ElementPickerUses,
+        COUNT(*) AS UsageCount
+    FROM ElementTypeUsage
+    GROUP BY ElementTypeId
+) U ON U.ElementTypeId = ET.nodeId
+WHERE ET.isElement = 1
+ORDER BY ETN.[text]");
+
+            var result = scope.Database.Fetch<ElementTypeUsageSummary>(sql);
+
+            this.memoryCache.Set(ElementTypeUsageSummaryCacheKey, result, ElementTypeUsageSummaryCacheDuration);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets every individual usage occurrence for a single Element Type, across all sources.
+        /// </summary>
+        public IEnumerable<ElementTypeUsageDetail> GetElementTypeUsageDetail(Guid elementTypeKey)
+        {
+            ElementTypeUsageStatus status = GetElementTypeUsageStatus();
+            if (!status.IsSupported)
+            {
+                return [];
+            }
+
+            using var scope = this.scopeProvider.CreateScope(autoComplete: true);
+
+            var sql = new Sql(BuildElementTypeUsageCte(status.LibraryFeatureAvailable, this.scopeProvider.SqlContext.DatabaseType) + @"
+SELECT
+    ContentNodeId,
+    ContentKey,
+    ContentName,
+    ParentName,
+    ContentPath,
+    VersionDate,
+    SourceType,
+    CASE
+        WHEN ReferencingNodeObjectType = @0 THEN 'content'
+        WHEN ReferencingNodeObjectType = @1 THEN 'media'
+        WHEN ReferencingNodeObjectType = @2 THEN 'member'
+        WHEN ReferencingNodeObjectType = @3 THEN 'element'
+        ELSE 'unknown'
+    END AS EntityType
+FROM ElementTypeUsage
+WHERE ElementTypeKey = @4
+ORDER BY SourceType, ContentPath",
+                Constants.ObjectTypes.Strings.Document,
+                Constants.ObjectTypes.Strings.Media,
+                Constants.ObjectTypes.Strings.Member,
+                ElementObjectTypeString,
+                elementTypeKey);
+
+            return scope.Database.Fetch<ElementTypeUsageDetail>(sql);
+        }
+
+        /// <summary>
+        /// Builds the shared Element Type usage CTE, always including BlockContent/BlockSettings,
+        /// and conditionally including LibraryItem / ElementPicker sources when the Umbraco 18+
+        /// <c>umbracoElement</c> table is present. BlockContent/BlockSettings extraction branches
+        /// on database type: SQL Server uses OPENJSON, SQLite uses the JSON1 extension's
+        /// json_each/json_extract (bundled with the SQLite provider Umbraco ships). ElementPicker
+        /// and LibraryItem are plain relational joins and are identical on both providers.
+        /// </summary>
+        private static string BuildElementTypeUsageCte(bool includeLibrarySources, DatabaseType databaseType)
+        {
+            // Leading semicolon is required: NPoco's EnableAutoSelect otherwise prepends
+            // "SELECT <cols> FROM <table>" to any query that doesn't start with SELECT/EXEC,
+            // which mangles a CTE's leading WITH into an invalid table hint. NPoco explicitly
+            // strips a leading ";" and skips that rewrite (see NPoco.AutoSelectHelper.AddSelectClause).
+            const string cteHeaderSql = @";
+WITH BlockPropertyTypes AS
+(
+    SELECT cpt.id
+    FROM cmsPropertyType cpt
+    INNER JOIN umbracoDataType udt ON udt.nodeId = cpt.dataTypeId
+    WHERE udt.propertyEditorAlias IN ('Umbraco.BlockList', 'Umbraco.BlockGrid')
+),
+ElementTypeUsage AS
+(";
+
+            // SQL Server: CROSS APPLY OPENJSON, typed straight to uniqueidentifier so the join and
+            // the later comparisons against Constants.ObjectTypes.Strings.* are case-insensitive by
+            // virtue of being a real GUID comparison rather than a string comparison.
+            const string sqlServerBlockSourcesSql = @"
+    SELECT DISTINCT
+        ucv.nodeId AS ContentNodeId,
+        un.uniqueId AS ContentKey,
+        ucv.[text] AS ContentName,
+        up.[text] AS ParentName,
+        un.[path] AS ContentPath,
+        ucv.versionDate AS VersionDate,
+        un.nodeObjectType AS ReferencingNodeObjectType,
+        JsonData.contentTypeKey AS ElementTypeKey,
+        et.[text] AS ElementTypeName,
+        et.id AS ElementTypeId,
+        JsonData.SourceType AS SourceType
+    FROM umbracoPropertyData upd
+    INNER JOIN umbracoContentVersion ucv ON ucv.id = upd.versionId
+    INNER JOIN umbracoNode un ON un.id = ucv.nodeId
+    LEFT JOIN umbracoNode up ON up.id = un.parentId
+    INNER JOIN BlockPropertyTypes bpt ON bpt.id = upd.propertyTypeId
+    CROSS APPLY
+    (
+        SELECT contentTypeKey, 'BlockContent' AS SourceType
+        FROM OPENJSON(upd.textValue, '$.contentData') WITH (contentTypeKey UNIQUEIDENTIFIER '$.contentTypeKey')
+        UNION ALL
+        SELECT contentTypeKey, 'BlockSettings' AS SourceType
+        FROM OPENJSON(upd.textValue, '$.settingsData') WITH (contentTypeKey UNIQUEIDENTIFIER '$.contentTypeKey')
+    ) JsonData
+    INNER JOIN umbracoNode et ON et.uniqueId = JsonData.contentTypeKey
+    WHERE ucv.[current] = 1 AND JsonData.contentTypeKey IS NOT NULL";
+
+            // SQLite: json_each is a table-valued function that SQLite allows to be "left
+            // correlated" against a column from an earlier table in the same FROM clause (upd.
+            // textValue here) - but only when called directly in the FROM list, not from inside a
+            // derived subquery. So, unlike the SQL Server CROSS APPLY above, contentData and
+            // settingsData can't be combined into one shared derived table; they're written as two
+            // separate SELECTs unioned together instead. The join below requires an explicit
+            // COLLATE NOCASE: unlike umbracoNode.path/text, the uniqueId and nodeObjectType columns
+            // are plain TEXT (default BINARY collation) in Umbraco's SQLite schema - confirmed by
+            // inspecting a live database - and .NET's Guid.ToString() serializes the Block List
+            // JSON's contentTypeKey in lowercase while uniqueId is stored uppercase, so a plain "="
+            // silently matches zero rows without it.
+            const string sqliteBlockSourcesSql = @"
+    SELECT DISTINCT
+        ucv.nodeId AS ContentNodeId,
+        un.uniqueId AS ContentKey,
+        ucv.[text] AS ContentName,
+        up.[text] AS ParentName,
+        un.[path] AS ContentPath,
+        ucv.versionDate AS VersionDate,
+        un.nodeObjectType AS ReferencingNodeObjectType,
+        et.uniqueId AS ElementTypeKey,
+        et.[text] AS ElementTypeName,
+        et.id AS ElementTypeId,
+        'BlockContent' AS SourceType
+    FROM umbracoPropertyData upd
+    INNER JOIN umbracoContentVersion ucv ON ucv.id = upd.versionId
+    INNER JOIN umbracoNode un ON un.id = ucv.nodeId
+    LEFT JOIN umbracoNode up ON up.id = un.parentId
+    INNER JOIN BlockPropertyTypes bpt ON bpt.id = upd.propertyTypeId
+    , json_each(upd.textValue, '$.contentData') je
+    INNER JOIN umbracoNode et ON et.uniqueId = json_extract(je.value, '$.contentTypeKey') COLLATE NOCASE
+    WHERE ucv.[current] = 1
+
+    UNION ALL
+
+    SELECT DISTINCT
+        ucv.nodeId,
+        un.uniqueId,
+        ucv.[text],
+        up.[text],
+        un.[path],
+        ucv.versionDate,
+        un.nodeObjectType,
+        et.uniqueId,
+        et.[text],
+        et.id,
+        'BlockSettings'
+    FROM umbracoPropertyData upd
+    INNER JOIN umbracoContentVersion ucv ON ucv.id = upd.versionId
+    INNER JOIN umbracoNode un ON un.id = ucv.nodeId
+    LEFT JOIN umbracoNode up ON up.id = un.parentId
+    INNER JOIN BlockPropertyTypes bpt ON bpt.id = upd.propertyTypeId
+    , json_each(upd.textValue, '$.settingsData') je
+    INNER JOIN umbracoNode et ON et.uniqueId = json_extract(je.value, '$.contentTypeKey') COLLATE NOCASE
+    WHERE ucv.[current] = 1";
+
+            // Element Picker references and standing Library items. Both depend on the Umbraco 18+
+            // umbracoElement table, so they're only appended when it exists (see GetElementTypeUsageStatus).
+            const string librarySourcesSql = @"
+
+    UNION ALL
+
+    SELECT DISTINCT
+        referencingNode.id,
+        referencingNode.uniqueId,
+        rucv.[text],
+        rup.[text],
+        referencingNode.[path],
+        rucv.versionDate,
+        referencingNode.nodeObjectType,
+        et2.uniqueId,
+        et2.[text],
+        et2.id,
+        'ElementPicker'
+    FROM umbracoRelation r
+    INNER JOIN umbracoRelationType rt ON rt.id = r.relType AND rt.alias = 'umbElement'
+    INNER JOIN umbracoNode referencingNode ON referencingNode.id = r.parentId
+    INNER JOIN umbracoContentVersion rucv ON rucv.nodeId = referencingNode.id AND rucv.[current] = 1
+    LEFT JOIN umbracoNode rup ON rup.id = referencingNode.parentId
+    INNER JOIN umbracoNode pickedElementNode ON pickedElementNode.id = r.childId
+    INNER JOIN umbracoContent pickedElementContent ON pickedElementContent.nodeId = pickedElementNode.id
+    INNER JOIN umbracoNode et2 ON et2.id = pickedElementContent.contentTypeId
+
+    UNION ALL
+
+    SELECT DISTINCT
+        libNode.id,
+        libNode.uniqueId,
+        lucv.[text],
+        lup.[text],
+        libNode.[path],
+        lucv.versionDate,
+        libNode.nodeObjectType,
+        et3.uniqueId,
+        et3.[text],
+        et3.id,
+        CASE WHEN libNode.trashed = 1 THEN 'LibraryItem (Trashed)' ELSE 'LibraryItem' END
+    FROM umbracoElement ue
+    INNER JOIN umbracoNode libNode ON libNode.id = ue.nodeId
+    INNER JOIN umbracoContent uc ON uc.nodeId = libNode.id
+    INNER JOIN umbracoNode et3 ON et3.id = uc.contentTypeId
+    INNER JOIN umbracoContentVersion lucv ON lucv.nodeId = libNode.id AND lucv.[current] = 1
+    LEFT JOIN umbracoNode lup ON lup.id = libNode.parentId";
+
+            string blockSourcesSql = databaseType == DatabaseType.SQLite ? sqliteBlockSourcesSql : sqlServerBlockSourcesSql;
+
+            return cteHeaderSql + blockSourcesSql + (includeLibrarySources ? librarySourcesSql : string.Empty) + "\n)\n";
         }
 
         /// <summary>

--- a/Diplo.GodMode/Services/UmbracoDatabaseService.cs
+++ b/Diplo.GodMode/Services/UmbracoDatabaseService.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Logging;
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Extensions;
@@ -20,24 +22,17 @@ namespace Diplo.GodMode.Services
 
         /// <summary>
         /// Cache key for the aggregated Element Type usage summary. This query scans every Block
-        /// List/Grid property and (on Umbraco 18+) every Library item and Element Picker relation,
-        /// so it's cached briefly - this is a single-developer diagnostic tool, not a live report,
-        /// and usage patterns don't meaningfully change within a few minutes of browsing the grid.
+        /// List/Grid property and all block-editor configurations, so it is cached briefly.
         /// </summary>
         private const string ElementTypeUsageSummaryCacheKey = "Diplo.GodMode.ElementTypeUsageSummary";
 
         private static readonly TimeSpan ElementTypeUsageSummaryCacheDuration = TimeSpan.FromMinutes(5);
 
-        /// <summary>
-        /// The Umbraco 18+ table backing Library items. Its presence is used to detect whether the
-        /// Library feature (and therefore LibraryItem / ElementPicker usage reporting) is available.
-        /// </summary>
         private const string UmbracoElementTableName = "umbracoElement";
 
         /// <summary>
-        /// Mirrors Umbraco.Cms.Core.Constants.ObjectTypes.Strings.Element in Umbraco 18+. GodMode's
-        /// server assembly targets Umbraco.Cms.Core [17.0.0,18.0.0), where the Element object type
-        /// does not exist, so this is hardcoded rather than referenced from Umbraco.Cms.Core.
+        /// Mirrors Umbraco.Cms.Core.Constants.ObjectTypes.Strings.Element in Umbraco 18. This
+        /// assembly targets Umbraco 17, where that constant is not available at compile time.
         /// </summary>
         private const string ElementObjectTypeString = "3D7B623C-94B1-487D-8554-A46EC37568BE";
 
@@ -45,13 +40,20 @@ namespace Diplo.GodMode.Services
         private readonly ILogger<UmbracoDatabaseService> logger;
         private readonly IPublishedContentQuery contentQuery;
         private readonly IMemoryCache memoryCache;
+        private readonly IDataTypeService dataTypeService;
 
-        public UmbracoDatabaseService(IScopeProvider scopeProvider, IPublishedContentQuery contentQuery, ILogger<UmbracoDatabaseService> logger, IMemoryCache memoryCache)
+        public UmbracoDatabaseService(
+            IScopeProvider scopeProvider,
+            IPublishedContentQuery contentQuery,
+            ILogger<UmbracoDatabaseService> logger,
+            IMemoryCache memoryCache,
+            IDataTypeService dataTypeService)
         {
             this.scopeProvider = scopeProvider;
             this.contentQuery = contentQuery;
             this.logger = logger;
             this.memoryCache = memoryCache;
+            this.dataTypeService = dataTypeService;
         }
 
         /// <summary>
@@ -449,11 +451,8 @@ namespace Diplo.GodMode.Services
         }
 
         /// <summary>
-        /// Reports whether Element Type Usage analysis can run on the current database, and whether
-        /// Library Item / Element Picker reporting is available. Supported on both SQL Server (via
-        /// OPENJSON) and SQLite (via the JSON1 extension's json_each/json_extract, bundled with the
-        /// SQLite provider Umbraco ships) so the analysis also works against a database pulled down
-        /// from Umbraco Cloud for local development.
+        /// Reports whether Element Type Usage analysis can run on the current database and detects
+        /// the optional Umbraco 18 Elements schema without taking a compile-time v18 dependency.
         /// </summary>
         public ElementTypeUsageStatus GetElementTypeUsageStatus()
         {
@@ -482,22 +481,21 @@ namespace Diplo.GodMode.Services
             {
                 IsSupported = true,
                 LibraryFeatureAvailable = libraryFeatureAvailable,
-                Message = libraryFeatureAvailable
-                    ? null
-                    : "Library Items and Element Picker usage require Umbraco 18+ (the umbracoElement table was not found). Only Block List / Block Grid usage is reported."
+                Message = null
             };
         }
 
         /// <summary>
-        /// Gets aggregated Element Type usage counts for the Element Type Usage grid, including
-        /// Element Types with zero usages so unused types can be identified. Cached briefly (see
-        /// <see cref="ElementTypeUsageSummaryCacheDuration"/>) since this is a single-developer
-        /// diagnostic tool where usage doesn't meaningfully change minute to minute; use the grid's
-        /// reload button to force a fresh read once the cache entry expires.
+        /// Gets aggregated stored-block and block-editor-configuration usage counts. A refresh
+        /// request bypasses the short-lived cache so the UI reload action always performs a fresh read.
         /// </summary>
-        public IEnumerable<ElementTypeUsageSummary> GetElementTypeUsageSummary()
+        public async Task<IEnumerable<ElementTypeUsageSummary>> GetElementTypeUsageSummary(bool refresh = false)
         {
-            if (this.memoryCache.TryGetValue(ElementTypeUsageSummaryCacheKey, out IReadOnlyList<ElementTypeUsageSummary>? cached) && cached is not null)
+            if (refresh)
+            {
+                this.memoryCache.Remove(ElementTypeUsageSummaryCacheKey);
+            }
+            else if (this.memoryCache.TryGetValue(ElementTypeUsageSummaryCacheKey, out IReadOnlyList<ElementTypeUsageSummary>? cached) && cached is not null)
             {
                 return cached;
             }
@@ -508,9 +506,10 @@ namespace Diplo.GodMode.Services
                 return [];
             }
 
-            using var scope = this.scopeProvider.CreateScope(autoComplete: true);
-
-            var sql = new Sql(BuildElementTypeUsageCte(status.LibraryFeatureAvailable, this.scopeProvider.SqlContext.DatabaseType) + @"
+            List<ElementTypeUsageSummary> result;
+            using (var scope = this.scopeProvider.CreateScope(autoComplete: true))
+            {
+                var sql = new Sql(BuildElementTypeUsageCte(status.LibraryFeatureAvailable, this.scopeProvider.SqlContext.DatabaseType == DatabaseType.SQLite) + @"
 SELECT
     ET.nodeId AS ElementTypeId,
     ETN.uniqueId AS ElementTypeKey,
@@ -519,6 +518,7 @@ SELECT
     ET.icon AS Icon,
     COALESCE(U.ContentUses, 0) AS ContentUses,
     COALESCE(U.SettingsUses, 0) AS SettingsUses,
+    0 AS ConfiguredUses,
     COALESCE(U.LibraryItems, 0) AS LibraryItems,
     COALESCE(U.ElementPickerUses, 0) AS ElementPickerUses,
     COALESCE(U.UsageCount, 0) AS UsageCount
@@ -539,7 +539,19 @@ LEFT JOIN
 WHERE ET.isElement = 1
 ORDER BY ETN.[text]");
 
-            var result = scope.Database.Fetch<ElementTypeUsageSummary>(sql);
+                result = scope.Database.Fetch<ElementTypeUsageSummary>(sql);
+            }
+
+            var configuredUsage = await this.GetElementTypeConfigurationUsage();
+            var configuredCounts = configuredUsage
+                .GroupBy(x => x.ElementTypeKey)
+                .ToDictionary(group => group.Key, group => group.Count());
+
+            foreach (var item in result)
+            {
+                item.ConfiguredUses = configuredCounts.GetValueOrDefault(item.ElementTypeKey);
+                item.UsageCount += item.ConfiguredUses;
+            }
 
             this.memoryCache.Set(ElementTypeUsageSummaryCacheKey, result, ElementTypeUsageSummaryCacheDuration);
 
@@ -549,7 +561,7 @@ ORDER BY ETN.[text]");
         /// <summary>
         /// Gets every individual usage occurrence for a single Element Type, across all sources.
         /// </summary>
-        public IEnumerable<ElementTypeUsageDetail> GetElementTypeUsageDetail(Guid elementTypeKey)
+        public async Task<IEnumerable<ElementTypeUsageDetail>> GetElementTypeUsageDetail(Guid elementTypeKey)
         {
             ElementTypeUsageStatus status = GetElementTypeUsageStatus();
             if (!status.IsSupported)
@@ -557,9 +569,12 @@ ORDER BY ETN.[text]");
                 return [];
             }
 
-            using var scope = this.scopeProvider.CreateScope(autoComplete: true);
-
-            var sql = new Sql(BuildElementTypeUsageCte(status.LibraryFeatureAvailable, this.scopeProvider.SqlContext.DatabaseType) + @"
+            List<ElementTypeUsageDetail> result;
+            using (var scope = this.scopeProvider.CreateScope(autoComplete: true))
+            {
+                bool isSqlite = this.scopeProvider.SqlContext.DatabaseType == DatabaseType.SQLite;
+                string elementTypeKeyPredicate = BuildElementTypeUsageKeyPredicate(isSqlite);
+                var sql = new Sql(BuildElementTypeUsageCte(status.LibraryFeatureAvailable, isSqlite) + $@"
 SELECT
     ContentNodeId,
     ContentKey,
@@ -576,7 +591,7 @@ SELECT
         ELSE 'unknown'
     END AS EntityType
 FROM ElementTypeUsage
-WHERE ElementTypeKey = @4
+WHERE {elementTypeKeyPredicate}
 ORDER BY SourceType, ContentPath",
                 Constants.ObjectTypes.Strings.Document,
                 Constants.ObjectTypes.Strings.Media,
@@ -584,18 +599,23 @@ ORDER BY SourceType, ContentPath",
                 ElementObjectTypeString,
                 elementTypeKey);
 
-            return scope.Database.Fetch<ElementTypeUsageDetail>(sql);
+                result = scope.Database.Fetch<ElementTypeUsageDetail>(sql);
+            }
+
+            result.AddRange((await this.GetElementTypeConfigurationUsage())
+                .Where(x => x.ElementTypeKey == elementTypeKey));
+
+            return result.OrderBy(x => x.SourceType).ThenBy(x => x.ContentName);
         }
 
+        internal static string BuildElementTypeUsageKeyPredicate(bool isSqlite)
+            => isSqlite ? "ElementTypeKey = @4 COLLATE NOCASE" : "ElementTypeKey = @4";
+
         /// <summary>
-        /// Builds the shared Element Type usage CTE, always including BlockContent/BlockSettings,
-        /// and conditionally including LibraryItem / ElementPicker sources when the Umbraco 18+
-        /// <c>umbracoElement</c> table is present. BlockContent/BlockSettings extraction branches
-        /// on database type: SQL Server uses OPENJSON, SQLite uses the JSON1 extension's
-        /// json_each/json_extract (bundled with the SQLite provider Umbraco ships). ElementPicker
-        /// and LibraryItem are plain relational joins and are identical on both providers.
+        /// Builds the shared usage CTE. Stored blocks use provider-specific JSON functions; Library
+        /// Item and Element Picker sources are appended only when the Elements schema is available.
         /// </summary>
-        private static string BuildElementTypeUsageCte(bool includeLibrarySources, DatabaseType databaseType)
+        internal static string BuildElementTypeUsageCte(bool includeLibrarySources, bool isSqlite)
         {
             // Leading semicolon is required: NPoco's EnableAutoSelect otherwise prepends
             // "SELECT <cols> FROM <table>" to any query that doesn't start with SELECT/EXEC,
@@ -604,10 +624,10 @@ ORDER BY SourceType, ContentPath",
             const string cteHeaderSql = @";
 WITH BlockPropertyTypes AS
 (
-    SELECT cpt.id
+    SELECT cpt.id, udt.propertyEditorAlias AS EditorAlias
     FROM cmsPropertyType cpt
     INNER JOIN umbracoDataType udt ON udt.nodeId = cpt.dataTypeId
-    WHERE udt.propertyEditorAlias IN ('Umbraco.BlockList', 'Umbraco.BlockGrid')
+    WHERE udt.propertyEditorAlias IN ('Umbraco.BlockList', 'Umbraco.BlockGrid', 'Umbraco.RichText')
 ),
 ElementTypeUsage AS
 (";
@@ -616,7 +636,7 @@ ElementTypeUsage AS
             // the later comparisons against Constants.ObjectTypes.Strings.* are case-insensitive by
             // virtue of being a real GUID comparison rather than a string comparison.
             const string sqlServerBlockSourcesSql = @"
-    SELECT DISTINCT
+    SELECT
         ucv.nodeId AS ContentNodeId,
         un.uniqueId AS ContentKey,
         ucv.[text] AS ContentName,
@@ -636,10 +656,22 @@ ElementTypeUsage AS
     CROSS APPLY
     (
         SELECT contentTypeKey, 'BlockContent' AS SourceType
-        FROM OPENJSON(upd.textValue, '$.contentData') WITH (contentTypeKey UNIQUEIDENTIFIER '$.contentTypeKey')
+        FROM OPENJSON(
+            CASE WHEN ISJSON(upd.textValue) = 1 THEN
+                CASE WHEN bpt.EditorAlias = 'Umbraco.RichText'
+                    THEN JSON_QUERY(upd.textValue, '$.blocks.contentData')
+                    ELSE JSON_QUERY(upd.textValue, '$.contentData')
+                END
+            END) WITH (contentTypeKey UNIQUEIDENTIFIER '$.contentTypeKey')
         UNION ALL
         SELECT contentTypeKey, 'BlockSettings' AS SourceType
-        FROM OPENJSON(upd.textValue, '$.settingsData') WITH (contentTypeKey UNIQUEIDENTIFIER '$.contentTypeKey')
+        FROM OPENJSON(
+            CASE WHEN ISJSON(upd.textValue) = 1 THEN
+                CASE WHEN bpt.EditorAlias = 'Umbraco.RichText'
+                    THEN JSON_QUERY(upd.textValue, '$.blocks.settingsData')
+                    ELSE JSON_QUERY(upd.textValue, '$.settingsData')
+                END
+            END) WITH (contentTypeKey UNIQUEIDENTIFIER '$.contentTypeKey')
     ) JsonData
     INNER JOIN umbracoNode et ON et.uniqueId = JsonData.contentTypeKey
     WHERE ucv.[current] = 1 AND JsonData.contentTypeKey IS NOT NULL";
@@ -656,7 +688,7 @@ ElementTypeUsage AS
             // JSON's contentTypeKey in lowercase while uniqueId is stored uppercase, so a plain "="
             // silently matches zero rows without it.
             const string sqliteBlockSourcesSql = @"
-    SELECT DISTINCT
+    SELECT
         ucv.nodeId AS ContentNodeId,
         un.uniqueId AS ContentKey,
         ucv.[text] AS ContentName,
@@ -673,13 +705,18 @@ ElementTypeUsage AS
     INNER JOIN umbracoNode un ON un.id = ucv.nodeId
     LEFT JOIN umbracoNode up ON up.id = un.parentId
     INNER JOIN BlockPropertyTypes bpt ON bpt.id = upd.propertyTypeId
-    , json_each(upd.textValue, '$.contentData') je
+    , json_each(CASE WHEN json_valid(upd.textValue) THEN
+        CASE WHEN bpt.EditorAlias = 'Umbraco.RichText'
+            THEN json_extract(upd.textValue, '$.blocks.contentData')
+            ELSE json_extract(upd.textValue, '$.contentData')
+        END
+      END) je
     INNER JOIN umbracoNode et ON et.uniqueId = json_extract(je.value, '$.contentTypeKey') COLLATE NOCASE
     WHERE ucv.[current] = 1
 
     UNION ALL
 
-    SELECT DISTINCT
+    SELECT
         ucv.nodeId,
         un.uniqueId,
         ucv.[text],
@@ -696,17 +733,23 @@ ElementTypeUsage AS
     INNER JOIN umbracoNode un ON un.id = ucv.nodeId
     LEFT JOIN umbracoNode up ON up.id = un.parentId
     INNER JOIN BlockPropertyTypes bpt ON bpt.id = upd.propertyTypeId
-    , json_each(upd.textValue, '$.settingsData') je
+    , json_each(CASE WHEN json_valid(upd.textValue) THEN
+        CASE WHEN bpt.EditorAlias = 'Umbraco.RichText'
+            THEN json_extract(upd.textValue, '$.blocks.settingsData')
+            ELSE json_extract(upd.textValue, '$.settingsData')
+        END
+      END) je
     INNER JOIN umbracoNode et ON et.uniqueId = json_extract(je.value, '$.contentTypeKey') COLLATE NOCASE
     WHERE ucv.[current] = 1";
 
-            // Element Picker references and standing Library items. Both depend on the Umbraco 18+
-            // umbracoElement table, so they're only appended when it exists (see GetElementTypeUsageStatus).
+            // Both sources are v18-only and are appended only after capability detection confirms
+            // the Elements table exists. Keep this SQL isolated so the v17 execution path never
+            // parses or resolves v18-only tables.
             const string librarySourcesSql = @"
 
     UNION ALL
 
-    SELECT DISTINCT
+    SELECT
         referencingNode.id,
         referencingNode.uniqueId,
         rucv.[text],
@@ -729,7 +772,7 @@ ElementTypeUsage AS
 
     UNION ALL
 
-    SELECT DISTINCT
+    SELECT
         libNode.id,
         libNode.uniqueId,
         lucv.[text],
@@ -748,9 +791,64 @@ ElementTypeUsage AS
     INNER JOIN umbracoContentVersion lucv ON lucv.nodeId = libNode.id AND lucv.[current] = 1
     LEFT JOIN umbracoNode lup ON lup.id = libNode.parentId";
 
-            string blockSourcesSql = databaseType == DatabaseType.SQLite ? sqliteBlockSourcesSql : sqlServerBlockSourcesSql;
+            string blockSourcesSql = isSqlite ? sqliteBlockSourcesSql : sqlServerBlockSourcesSql;
 
-            return cteHeaderSql + blockSourcesSql + (includeLibrarySources ? librarySourcesSql : string.Empty) + "\n)\n";
+            return cteHeaderSql
+                + blockSourcesSql
+                + (includeLibrarySources ? librarySourcesSql : string.Empty)
+                + "\n)\n";
+        }
+
+        private async Task<List<ElementTypeUsageDetail>> GetElementTypeConfigurationUsage()
+        {
+            var result = new List<ElementTypeUsageDetail>();
+            var dataTypes = await this.dataTypeService.GetAllAsync();
+
+            foreach (var dataType in dataTypes)
+            {
+                foreach (var reference in GetConfiguredElementTypeReferences(dataType.ConfigurationObject))
+                {
+                    result.Add(new ElementTypeUsageDetail
+                    {
+                        ContentNodeId = dataType.Id,
+                        ContentKey = dataType.Key,
+                        ContentName = dataType.Name ?? "Unnamed data type",
+                        ParentName = dataType.EditorAlias,
+                        ContentPath = "Data Type configuration",
+                        VersionDate = dataType.UpdateDate,
+                        SourceType = reference.SourceType,
+                        EntityType = "dataType",
+                        ElementTypeKey = reference.ElementTypeKey
+                    });
+                }
+            }
+
+            return result;
+        }
+
+        internal static IEnumerable<ElementTypeConfigurationReference> GetConfiguredElementTypeReferences(object configuration)
+        {
+            IEnumerable<(Guid? ContentKey, Guid? SettingsKey)> blocks = configuration switch
+            {
+                BlockListConfiguration blockList => blockList.Blocks?.Select(x => ((Guid?)x.ContentElementTypeKey, x.SettingsElementTypeKey)) ?? [],
+                BlockGridConfiguration blockGrid => blockGrid.Blocks?.Select(x => ((Guid?)x.ContentElementTypeKey, x.SettingsElementTypeKey)) ?? [],
+                RichTextConfiguration richText => richText.Blocks?.Select(x => ((Guid?)x.ContentElementTypeKey, x.SettingsElementTypeKey)) ?? [],
+                SingleBlockConfiguration singleBlock => singleBlock.Blocks?.Select(x => ((Guid?)x.ContentElementTypeKey, x.SettingsElementTypeKey)) ?? [],
+                _ => []
+            };
+
+            foreach (var block in blocks)
+            {
+                if (block.ContentKey.HasValue)
+                {
+                    yield return new ElementTypeConfigurationReference(block.ContentKey.Value, "ConfigurationContent");
+                }
+
+                if (block.SettingsKey.HasValue)
+                {
+                    yield return new ElementTypeConfigurationReference(block.SettingsKey.Value, "ConfigurationSettings");
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## What

Adds a new **Element Type Usage** view under **Relationships & Usage**, giving a single grid that shows, for every Element Type in the install, where it's actually being used:

- **Block List / Block Grid** — content and settings data
- **Library Items** (Umbraco 18+) — standing elements in the Library section
- **Element Picker** (Umbraco 18+) — properties that reference a Library item

Each row shows a per-source breakdown (Content Uses / Settings Uses / Library Items / Element Picker Uses) plus a total Usage Count, so Element Types with zero usages anywhere are easy to spot and clean up. Clicking a row opens a detail modal listing every individual occurrence (content name, parent, path, version date, source type), with a working link through to the owning content/media/member/library item.

## Why

Element Types have no first-party "where is this used" report in Umbraco — unlike Data Types, which show usage across Document Types. Once a project has been running for a while it's common to accumulate orphaned Element Types (renamed, superseded, or left over from an old design), and there was no quick way to confirm one was safe to delete. This closes that gap, and also gives early visibility into the new Umbraco 18 Library/Element Picker feature, which has no built-in usage report at all yet.

## How it works

- Read-only. No new database tables or schema changes — everything is computed via SQL against existing Umbraco tables (`cmsContentType`, `umbracoPropertyData`, `umbracoContentVersion`, `umbracoRelation`, and — on Umbraco 18+ — `umbracoElement`).
- Block List/Grid `contentData`/`settingsData` JSON blobs are parsed server-side (SQL Server via `OPENJSON`/`CROSS APPLY`; SQLite via the JSON1 extension's `json_each`/`json_extract`) to find embedded Element Type references without needing to touch application-layer block value converters.
- Library Item and Element Picker sources are only included when the Umbraco 18+ `umbracoElement` table is detected at runtime — the feature degrades gracefully rather than erroring on Umbraco 17.
- A `/element-type-usage/status` endpoint reports whether the analysis can run at all (requires SQL Server compat level 130+, or SQLite) and whether Library sources are available, so the UI can show an explanatory message instead of an empty/broken grid on unsupported setups.
- The aggregated summary query is cached for 5 minutes (`IMemoryCache`) since this is a diagnostic tool, not a live report; detail queries are intentionally uncached since they're cheap and freshness matters more there. Mirrors the existing `GetDatabaseTables` caching pattern.

## Compatibility

- **SQL Server**: requires compatibility level ≥ 130 (needed for `OPENJSON`). Reported via the status endpoint rather than failing silently.
- **SQLite**: fully supported via a separate SQL branch using `json_each`/`json_extract` instead of `OPENJSON` (SQLite has no native lateral-correlation into a subquery, so Block Content and Block Settings are two `UNION ALL`'d top-level `SELECT`s rather than one derived table). Includes an explicit `COLLATE NOCASE` on the Element Type join, since `umbracoNode.uniqueId` is case-sensitive TEXT in the SQLite schema while block JSON serializes GUIDs lowercase.
- **Umbraco 17.x**: Block List/Grid usage only; Library Items/Element Picker columns report 0 with an explanatory note, since the feature doesn't exist yet.
- **Umbraco 18.x**: full support, including Library Items and Element Picker.

## Testing performed

Manually verified end-to-end against three real environments by referencing this branch's `Diplo.GodMode.csproj` locally:

- A client's real Block Grid-heavy site on **SQL Server** (Umbraco 17)
- A local **SQLite** Umbraco 17.4 install — this is where a genuine collation bug was found and fixed (SQLite join silently matched 0 rows without `COLLATE NOCASE`; confirmed via direct inspection of the live `.sqlite.db`, then verified the fix produced correct non-zero counts)
- A local **SQLite** Umbraco 18.1 install with the native Library feature enabled, to exercise the Library Item / Element Picker code paths for real

No new NuGet packages were added. UI built with Lit/TypeScript following existing GodMode conventions (shared sort/pager/modal helpers, scoped component styles).

## Screenshots

V18 site with Library:
<img width="1597" height="880" alt="image" src="https://github.com/user-attachments/assets/7b3c0e48-0505-49ff-aabf-e9013310b249" />

Search:
<img width="1562" height="537" alt="image" src="https://github.com/user-attachments/assets/b8788e4e-f7aa-42c0-8aaf-ea74e9414784" />

Details: eg where used:
<img width="1097" height="861" alt="image" src="https://github.com/user-attachments/assets/21170b7b-294a-4f9f-ad38-b156e9a16142" />

For Library Items:
<img width="1064" height="777" alt="image" src="https://github.com/user-attachments/assets/8c7cfd99-97d9-4bae-a0dd-877a43a963db" />

V17 site Block Grid Heavy:
<img width="2564" height="1626" alt="image" src="https://github.com/user-attachments/assets/e2e86994-190a-4137-8c54-5b54a524dd2a" />

Find Unused:

<img width="2618" height="1628" alt="image" src="https://github.com/user-attachments/assets/8aa5bd16-d9ea-41eb-92a7-acd9b8057758" />

What do you reckon Dan? do I get a GodMode contrib badge?











